### PR TITLE
fix(payment): settle provider events that arrive before the order exists

### DIFF
--- a/packages/api/src/Actions/CompleteCartAction.php
+++ b/packages/api/src/Actions/CompleteCartAction.php
@@ -15,9 +15,12 @@ use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Exceptions\CampaignBudgetExceededException;
 use Shopper\Core\Models\Contracts\Order;
+use Shopper\Payment\Actions\SettlePayment;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Jobs\SyncPendingPaymentJob;
 use Shopper\Payment\Models\PaymentTransaction;
+use Throwable;
 
 final readonly class CompleteCartAction
 {
@@ -25,6 +28,7 @@ final readonly class CompleteCartAction
         private GetCartShippingOptionsAction $shippingOptions,
         private CartManager $cartManager,
         private CreateOrderFromCartAction $createOrderFromCart,
+        private SettlePayment $settle,
     ) {}
 
     /**
@@ -82,7 +86,38 @@ final readonly class CompleteCartAction
             ]);
         }
 
+        $this->settlePayment($cart, $order);
+
         return $order;
+    }
+
+    /**
+     * The browser confirms the payment before the storefront completes the
+     * cart, so the provider often speaks before the order exists. Once the
+     * order and its initiate transaction are committed, the events that
+     * landed early are replayed, and a provider check is queued for a
+     * payment still pending: the response never waits on the provider, and
+     * placement is never blocked by the settlement. The order is the durable
+     * anchor, the scheduled reconciliation is the safety net.
+     */
+    private function settlePayment(Cart $cart, Order $order): void
+    {
+        $reference = $cart->payment_session['reference'] ?? null;
+
+        if (! is_string($reference)) {
+            return;
+        }
+
+        try {
+            $this->settle->execute($reference);
+
+            if (config('shopper.payment.reconciliation.pull_on_completion', true)) {
+                SyncPendingPaymentJob::dispatch($order->getKey(), $reference)
+                    ->onQueue(config('shopper.payment.reconciliation.queue'));
+            }
+        } catch (Throwable $exception) {
+            report($exception);
+        }
     }
 
     /**

--- a/packages/api/src/Http/Controllers/Cart/CompleteCartController.php
+++ b/packages/api/src/Http/Controllers/Cart/CompleteCartController.php
@@ -28,7 +28,8 @@ final class CompleteCartController
      * holds shippable lines. Placement is idempotent: completing an already
      * completed cart answers 200 with the order it produced, so a client
      * retrying a timed-out call never creates a duplicate. The actual money
-     * movement is confirmed asynchronously through the payment webhooks.
+     * movement is confirmed through the payment webhooks: those that arrived
+     * before the order existed are settled here, the rest land later.
      */
     public function __invoke(Request $request, string $cartId): JsonResponse
     {

--- a/packages/api/src/Http/Controllers/Payment/WebhookController.php
+++ b/packages/api/src/Http/Controllers/Payment/WebhookController.php
@@ -6,16 +6,14 @@ namespace Shopper\Api\Http\Controllers\Payment;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Actions\IngestPaymentEvent;
 use Shopper\Payment\Facades\Payment;
-use Shopper\Payment\Models\PaymentWebhookEvent;
-use Shopper\Payment\Services\PaymentProcessingService;
 use Throwable;
 
 final class WebhookController
 {
     public function __construct(
-        private readonly PaymentProcessingService $service,
+        private readonly IngestPaymentEvent $ingest,
     ) {}
 
     public function __invoke(Request $request, string $driver): JsonResponse
@@ -33,44 +31,9 @@ final class WebhookController
             return response()->json(['error' => 'Invalid webhook payload.'], 400);
         }
 
-        if ($result->isIgnored()) {
-            return response()->json(['received' => true]);
-        }
-
-        if (! $this->firstDelivery($driver, $result)) {
-            return response()->json(['received' => true]);
-        }
-
-        $this->service->processWebhook($driver, $result);
+        $this->ingest->execute($driver, $result);
 
         return response()->json(['received' => true]);
-    }
-
-    /**
-     * Record the event id once. A duplicate delivery is ignored at the database
-     * level and reports false so the caller can acknowledge without
-     * reprocessing. insertOrIgnore avoids the failed-INSERT that would abort the
-     * surrounding transaction on Postgres.
-     */
-    private function firstDelivery(string $driver, WebhookResult $result): bool
-    {
-        if ($result->eventId === null) {
-            return true;
-        }
-
-        $now = now();
-
-        $inserted = PaymentWebhookEvent::query()->insertOrIgnore([
-            'driver' => $driver,
-            'event_id' => $result->eventId,
-            'type' => $result->action,
-            'payload' => json_encode($result->toArray()),
-            'processed_at' => $now,
-            'created_at' => $now,
-            'updated_at' => $now,
-        ]);
-
-        return $inserted > 0;
     }
 
     /**

--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -37,11 +37,13 @@ return [
     |
     | Here you may define the number of hours after which unpaid pending
     | orders are automatically cancelled and their reserved stock released.
-    | When set, the `shopper:orders:reclaim` command runs hourly. Use null
-    | to disable. Orders paid offline (manual driver) are never reclaimed.
+    | A failed payment attempt never cancels an order on its own, since the
+    | customer may still retry: this window is what frees the stock when no
+    | payment ever lands. The `shopper:orders:reclaim` command runs hourly.
+    | Use null to disable. Offline payments (manual driver) are never reclaimed.
     |
     */
 
-    'reclaim_pending_after_hours' => null,
+    'reclaim_pending_after_hours' => 24,
 
 ];

--- a/packages/core/src/Console/ReclaimPendingOrdersCommand.php
+++ b/packages/core/src/Console/ReclaimPendingOrdersCommand.php
@@ -7,7 +7,6 @@ namespace Shopper\Core\Console;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
 use Shopper\Core\Enum\OrderStatus;
-use Shopper\Core\Enum\PaymentStatus;
 use Shopper\Core\Events\Orders\OrderCancelled;
 use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Order;
@@ -36,8 +35,7 @@ final class ReclaimPendingOrdersCommand extends Command
         $reclaimed = 0;
 
         resolve(OrderContract::class)::query()
-            ->where('payment_status', PaymentStatus::Pending)
-            ->where('status', OrderStatus::New)
+            ->awaitingPayment()
             ->where('created_at', '<', now()->subHours($hours))
             ->whereHas('paymentMethod', function ($query): void {
                 $query->whereNotNull('driver')->where('driver', '<>', 'manual');

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -177,6 +177,12 @@ class Order extends Model implements OrderContract
         return $this->payment_status === PaymentStatus::Authorized;
     }
 
+    public function isAwaitingPayment(): bool
+    {
+        return $this->payment_status === PaymentStatus::Pending
+            && $this->status === OrderStatus::New;
+    }
+
     public function isRefunded(): bool
     {
         return $this->payment_status === PaymentStatus::Refunded;
@@ -339,6 +345,18 @@ class Order extends Model implements OrderContract
     protected function archived(Builder $query): Builder
     {
         return $query->where('status', OrderStatus::Archived);
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     * @return Builder<Order>
+     */
+    #[Scope]
+    protected function awaitingPayment(Builder $query): Builder
+    {
+        return $query
+            ->where('payment_status', PaymentStatus::Pending)
+            ->where('status', OrderStatus::New);
     }
 
     protected function casts(): array

--- a/packages/payment/config/payment.php
+++ b/packages/payment/config/payment.php
@@ -41,4 +41,27 @@ return [
 
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Payment Reconciliation
+    |--------------------------------------------------------------------------
+    |
+    | Here you may control how an order catches up with the provider events
+    | that arrived before it existed. When a cart is completed the stored
+    | events are replayed and a provider check is queued for a payment still
+    | pending. Every fifteen minutes the scheduled command replays what is
+    | still unprocessed and queues a check for every pending payment. The
+    | checks run on the queue configured here, and the event ledger is
+    | pruned daily past the retention below.
+    |
+    */
+
+    'reconciliation' => [
+        'pull_on_completion' => env('PAYMENT_PULL_ON_COMPLETION', true),
+        'schedule' => env('PAYMENT_RECONCILE_SCHEDULE', true),
+        'queue' => env('PAYMENT_RECONCILE_QUEUE'),
+        'backoff' => [60, 300, 900],
+        'prune_after_days' => env('PAYMENT_WEBHOOK_EVENTS_PRUNE_AFTER_DAYS', 90),
+    ],
+
 ];

--- a/packages/payment/database/factories/PaymentWebhookEventFactory.php
+++ b/packages/payment/database/factories/PaymentWebhookEventFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Enum\WebhookAction;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+
+/**
+ * @extends Factory<PaymentWebhookEvent>
+ */
+class PaymentWebhookEventFactory extends Factory
+{
+    protected $model = PaymentWebhookEvent::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $eventId = 'evt_'.$this->faker->unique()->uuid();
+        $reference = 'pi_'.$this->faker->unique()->uuid();
+
+        return [
+            'driver' => 'manual',
+            'event_id' => $eventId,
+            'type' => WebhookAction::Captured,
+            'reference' => $reference,
+            'payload' => (new WebhookResult(action: WebhookAction::Captured, reference: $reference, eventId: $eventId))->toArray(),
+            'processed_at' => null,
+        ];
+    }
+
+    public function fromResult(WebhookResult $result): static
+    {
+        return $this->state(function (array $attributes) use ($result): array {
+            $eventId = $result->eventId ?? $attributes['event_id'];
+
+            return [
+                'event_id' => $eventId,
+                'type' => $result->action,
+                'reference' => $result->reference,
+                'payload' => [...$result->toArray(), 'event_id' => $eventId],
+            ];
+        });
+    }
+
+    public function processed(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'processed_at' => now(),
+        ]);
+    }
+}

--- a/packages/payment/database/migrations/2026_09_02_000001_add_reference_to_payment_webhook_events_table.php
+++ b/packages/payment/database/migrations/2026_09_02_000001_add_reference_to_payment_webhook_events_table.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Shopper\Core\Helpers\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $table = $this->getTableName('payment_webhook_events');
+
+        Schema::table($table, static function (Blueprint $table): void {
+            $table->string('reference')->nullable()->after('type')->index();
+            $table->index('processed_at');
+        });
+
+        $this->backfill($table, $this->getTableName('payment_transactions'));
+    }
+
+    public function down(): void
+    {
+        Schema::table($this->getTableName('payment_webhook_events'), static function (Blueprint $table): void {
+            $table->dropIndex(['processed_at']);
+            $table->dropIndex(['reference']);
+            $table->dropColumn('reference');
+        });
+    }
+
+    /**
+     * processed_at used to mean "received" and now means "applied to an
+     * order". An event journalized before any transaction carried its
+     * reference had no order to apply to, so it is put back in line for the
+     * reconcile command; re-applying an already settled event is a no-op.
+     */
+    private function backfill(string $events, string $transactions): void
+    {
+        DB::table($events)
+            ->whereNull('reference')
+            ->orderBy('id')
+            ->chunkById(500, static function (Collection $rows) use ($events, $transactions): void {
+                foreach ($rows as $row) {
+                    $payload = json_decode((string) $row->payload, true);
+                    $reference = is_array($payload) ? ($payload['reference'] ?? null) : null;
+
+                    if (! is_string($reference)) {
+                        continue;
+                    }
+
+                    $journalized = DB::table($transactions)->where('reference', $reference)->min('created_at');
+
+                    $applied = $journalized !== null
+                        && Carbon::parse($journalized)->lt(Carbon::parse($row->created_at));
+
+                    DB::table($events)->where('id', $row->id)->update([
+                        'reference' => $reference,
+                        'processed_at' => $applied ? $row->processed_at : null,
+                    ]);
+                }
+            });
+    }
+};

--- a/packages/payment/src/Actions/ApplyPaymentEvent.php
+++ b/packages/payment/src/Actions/ApplyPaymentEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+use Shopper\Payment\Services\PaymentProcessingService;
+
+final readonly class ApplyPaymentEvent
+{
+    public function __construct(
+        private PaymentProcessingService $payments,
+    ) {}
+
+    public function execute(PaymentWebhookEvent $event): bool
+    {
+        $result = $event->toWebhookResult();
+        $order = $result->reference === null ? null : $this->payments->findOrderByReference($result->reference);
+
+        if ($order === null) {
+            return false;
+        }
+
+        return DB::transaction(function () use ($event, $order, $result): bool {
+            if (! $event->claim()) {
+                return false;
+            }
+
+            $this->payments->apply($order, $event->driver, $result);
+
+            return true;
+        });
+    }
+}

--- a/packages/payment/src/Actions/IngestPaymentEvent.php
+++ b/packages/payment/src/Actions/IngestPaymentEvent.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Actions;
+
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+use Shopper\Payment\Services\PaymentProcessingService;
+
+final readonly class IngestPaymentEvent
+{
+    public function __construct(
+        private PaymentProcessingService $payments,
+        private ApplyPaymentEvent $apply,
+    ) {}
+
+    public function execute(string $driver, WebhookResult $result): void
+    {
+        if ($result->isIgnored() || $result->reference === null) {
+            return;
+        }
+
+        if ($result->eventId === null) {
+            $order = $this->payments->findOrderByReference($result->reference);
+
+            if ($order !== null) {
+                $this->payments->apply($order, $driver, $result);
+            }
+
+            return;
+        }
+
+        $event = PaymentWebhookEvent::journal($driver, $result);
+
+        if ($event !== null) {
+            $this->apply->execute($event);
+        }
+    }
+}

--- a/packages/payment/src/Actions/SettlePayment.php
+++ b/packages/payment/src/Actions/SettlePayment.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Actions;
+
+use Shopper\Payment\Models\PaymentWebhookEvent;
+
+final readonly class SettlePayment
+{
+    public function __construct(
+        private ApplyPaymentEvent $apply,
+    ) {}
+
+    public function execute(string $reference): void
+    {
+        PaymentWebhookEvent::query()
+            ->unprocessed()
+            ->forReference($reference)
+            ->orderBy('id')
+            ->get()
+            ->sortBy(fn (PaymentWebhookEvent $event): array => [$event->type?->precedence() ?? PHP_INT_MAX, $event->id])
+            ->each(fn (PaymentWebhookEvent $event) => $this->apply->execute($event));
+    }
+}

--- a/packages/payment/src/Actions/SyncPaymentWithProvider.php
+++ b/packages/payment/src/Actions/SyncPaymentWithProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Actions;
+
+use Shopper\Core\Models\Contracts\Order;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Enum\WebhookAction;
+use Shopper\Payment\PaymentManager;
+use Shopper\Payment\Services\PaymentProcessingService;
+
+final readonly class SyncPaymentWithProvider
+{
+    public function __construct(
+        private PaymentManager $paymentManager,
+        private PaymentProcessingService $payments,
+    ) {}
+
+    public function execute(Order $order, string $reference): void
+    {
+        if (! $order->refresh()->isAwaitingPayment()) {
+            return;
+        }
+
+        $method = $order->paymentMethod;
+
+        if ($method === null) {
+            return;
+        }
+
+        $driver = $this->paymentManager->driver($method->driver ?? 'manual');
+
+        if (! $driver->supportsRetrieval()) {
+            return;
+        }
+
+        $state = $driver->retrievePayment($reference);
+        $action = WebhookAction::tryFrom($state->status);
+
+        if (! in_array($action, [WebhookAction::Authorized, WebhookAction::Captured, WebhookAction::Canceled], strict: true)) {
+            return;
+        }
+
+        $this->payments->apply($order, $driver->code(), new WebhookResult(
+            action: $action,
+            reference: $reference,
+            amount: $state->amount,
+            data: $state->data,
+        ));
+    }
+}

--- a/packages/payment/src/Console/ReconcilePaymentsCommand.php
+++ b/packages/payment/src/Console/ReconcilePaymentsCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Str;
+use Shopper\Core\Models\Contracts\Order as OrderContract;
+use Shopper\Core\Models\Order;
+use Shopper\Payment\Actions\SettlePayment;
+use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Jobs\SyncPendingPaymentJob;
+use Shopper\Payment\Models\PaymentTransaction;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+use Shopper\Payment\Services\PaymentProcessingService;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'shopper:payments:reconcile')]
+final class ReconcilePaymentsCommand extends Command
+{
+    protected $signature = 'shopper:payments:reconcile
+                            {--pull : Queue a provider check for pending payments whose driver supports retrieval}
+                            {--minutes=15 : Only pull orders that have been pending for at least this many minutes}';
+
+    protected $description = 'Apply the provider events that arrived before their order existed, and optionally check pending payments against the provider';
+
+    public function handle(PaymentProcessingService $payments, SettlePayment $settle): int
+    {
+        ['settled' => $settled, 'unmatched' => $unmatched] = $this->replayEarlyEvents($payments, $settle);
+
+        $this->components->info("{$settled} ".Str::plural('payment', $settled).' settled from early provider events.');
+        $this->components->info("{$unmatched} ".Str::plural('event', $unmatched).' still without an order.');
+
+        if ($this->option('pull')) {
+            $queued = $this->queuePendingPayments((int) $this->option('minutes'));
+
+            $this->components->info("{$queued} pending ".Str::plural('payment', $queued).' queued for a provider check.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Events are settled per reference so the ordering rules of the
+     * settlement apply to the whole history of a payment. The reference list
+     * stays short: events find their order within seconds, only those of
+     * abandoned payment sessions linger.
+     *
+     * @return array{settled: int, unmatched: int}
+     */
+    private function replayEarlyEvents(PaymentProcessingService $payments, SettlePayment $settle): array
+    {
+        $settled = 0;
+        $unmatched = 0;
+
+        $references = PaymentWebhookEvent::query()
+            ->unprocessed()
+            ->whereNotNull('reference')
+            ->distinct()
+            ->pluck('reference');
+
+        foreach ($references as $reference) {
+            if ($payments->findOrderByReference($reference) === null) {
+                $unmatched++;
+
+                continue;
+            }
+
+            $settle->execute($reference);
+            $settled++;
+        }
+
+        return ['settled' => $settled, 'unmatched' => $unmatched];
+    }
+
+    private function queuePendingPayments(int $minutes): int
+    {
+        $queued = 0;
+        $queue = config('shopper.payment.reconciliation.queue');
+
+        resolve(OrderContract::class)::query()
+            ->awaitingPayment()
+            ->where('created_at', '<', now()->subMinutes($minutes))
+            ->whereHas('paymentMethod', function (Builder $query): void {
+                $query->whereNotNull('driver')->where('driver', '<>', 'manual');
+            })
+            ->chunkById(100, function (Collection $orders) use (&$queued, $queue): void {
+                /** @var Order $order */
+                foreach ($orders as $order) {
+                    $reference = PaymentTransaction::query()
+                        ->where('order_id', $order->getKey())
+                        ->where('type', TransactionType::Initiate)
+                        ->latest()
+                        ->value('reference');
+
+                    if (! is_string($reference)) {
+                        continue;
+                    }
+
+                    SyncPendingPaymentJob::dispatch($order->getKey(), $reference)->onQueue($queue);
+                    $queued++;
+                }
+            });
+
+        return $queued;
+    }
+}

--- a/packages/payment/src/Contracts/PaymentDriver.php
+++ b/packages/payment/src/Contracts/PaymentDriver.php
@@ -29,6 +29,11 @@ interface PaymentDriver
     public function supportsRefunds(): bool;
 
     /**
+     * Whether the provider can be asked for the current state of a payment.
+     */
+    public function supportsRetrieval(): bool;
+
+    /**
      * Initiate a payment session with the provider.
      *
      * Returns the data needed by the frontend (client_secret, order_id, etc.).
@@ -69,7 +74,11 @@ interface PaymentDriver
     public function retrievePayment(string $reference): PaymentResult;
 
     /**
-     * Process an incoming webhook event from the provider.
+     * Process an incoming webhook event from the provider. The reference is
+     * the payment reference the order was initiated with, and the event id is
+     * what makes a redelivery collapse. A refund event carries the amount of
+     * that refund alone, never a cumulative total, and its provider refund id
+     * under `data['refund_id']`.
      *
      * @param  array<string, mixed>  $payload
      * @param  array<string, mixed>  $headers

--- a/packages/payment/src/DataTransferObjects/WebhookResult.php
+++ b/packages/payment/src/DataTransferObjects/WebhookResult.php
@@ -4,13 +4,15 @@ declare(strict_types=1);
 
 namespace Shopper\Payment\DataTransferObjects;
 
+use Shopper\Payment\Enum\WebhookAction;
+
 final readonly class WebhookResult
 {
     /**
      * @param  array<string, mixed>  $data
      */
     public function __construct(
-        public string $action,
+        public WebhookAction $action,
         public ?string $reference = null,
         public ?int $amount = null,
         public array $data = [],
@@ -19,12 +21,50 @@ final readonly class WebhookResult
 
     public static function ignored(): self
     {
-        return new self(action: 'ignored');
+        return new self(action: WebhookAction::Ignored);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            action: WebhookAction::tryFrom((string) ($payload['action'] ?? '')) ?? WebhookAction::Ignored,
+            reference: isset($payload['reference']) ? (string) $payload['reference'] : null,
+            amount: isset($payload['amount']) ? (int) $payload['amount'] : null,
+            data: is_array($payload['data'] ?? null) ? $payload['data'] : [],
+            eventId: isset($payload['event_id']) ? (string) $payload['event_id'] : null,
+        );
     }
 
     public function isIgnored(): bool
     {
-        return $this->action === 'ignored';
+        return $this->action === WebhookAction::Ignored;
+    }
+
+    /**
+     * The provider's id for the refund itself, when the driver supplies it.
+     * A refund is journalized under that id rather than the payment
+     * reference so a redelivery, or the webhook confirming a refund issued
+     * from the admin, collapses onto the row already on file.
+     */
+    public function refundId(): ?string
+    {
+        $refundId = $this->data['refund_id'] ?? null;
+
+        return is_string($refundId) ? $refundId : null;
+    }
+
+    public function toPaymentResult(): PaymentResult
+    {
+        return new PaymentResult(
+            success: true,
+            status: $this->action->value,
+            reference: $this->refundId() ?? $this->reference,
+            amount: $this->amount,
+            data: $this->data,
+        );
     }
 
     /**
@@ -33,7 +73,7 @@ final readonly class WebhookResult
     public function toArray(): array
     {
         return [
-            'action' => $this->action,
+            'action' => $this->action->value,
             'reference' => $this->reference,
             'amount' => $this->amount,
             'data' => $this->data,

--- a/packages/payment/src/Drivers/Driver.php
+++ b/packages/payment/src/Drivers/Driver.php
@@ -32,6 +32,11 @@ abstract class Driver implements PaymentDriver
         return true;
     }
 
+    public function supportsRetrieval(): bool
+    {
+        return false;
+    }
+
     public function authorizePayment(string $reference, array $data = []): PaymentResult
     {
         throw PaymentException::notSupported('authorizePayment', $this->code());

--- a/packages/payment/src/Drivers/ManualDriver.php
+++ b/packages/payment/src/Drivers/ManualDriver.php
@@ -8,10 +8,6 @@ use Illuminate\Support\Str;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 
-/**
- * Manual driver for payment methods without API integration.
- * Acts as a cash-on-delivery (COD) or bank transfer placeholder.
- */
 final class ManualDriver extends Driver
 {
     public function code(): string

--- a/packages/payment/src/Enum/WebhookAction.php
+++ b/packages/payment/src/Enum/WebhookAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Enum;
+
+enum WebhookAction: string
+{
+    case Authorized = 'authorized';
+
+    case Captured = 'captured';
+
+    case Refunded = 'refunded';
+
+    case Canceled = 'canceled';
+
+    case Failed = 'failed';
+
+    case Ignored = 'ignored';
+
+    /**
+     * The order in which the events of one payment are replayed when they
+     * were journalized before their order existed. Providers do not promise
+     * delivery order, and a refund can only ever follow a capture.
+     */
+    public function precedence(): int
+    {
+        return match ($this) {
+            self::Authorized => 1,
+            self::Captured => 2,
+            self::Failed => 3,
+            self::Canceled => 4,
+            self::Refunded => 5,
+            self::Ignored => 6,
+        };
+    }
+}

--- a/packages/payment/src/Events/PaymentFailed.php
+++ b/packages/payment/src/Events/PaymentFailed.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Shopper\Payment\Events;
 
 use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 use Shopper\Core\Models\Contracts\Order;
 use Shopper\Payment\Enum\TransactionType;
 
-final class PaymentFailed
+final class PaymentFailed implements ShouldDispatchAfterCommit
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 

--- a/packages/payment/src/Jobs/SyncPendingPaymentJob.php
+++ b/packages/payment/src/Jobs/SyncPendingPaymentJob.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Payment\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Shopper\Core\Models\Contracts\Order;
+use Shopper\Payment\Actions\SyncPaymentWithProvider;
+
+final class SyncPendingPaymentJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public int $uniqueFor = 3600;
+
+    public function __construct(
+        private readonly int $orderId,
+        private readonly string $reference,
+    ) {}
+
+    public function uniqueId(): string
+    {
+        return "{$this->orderId}:{$this->reference}";
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return (array) config('shopper.payment.reconciliation.backoff', [60, 300, 900]);
+    }
+
+    public function tries(): int
+    {
+        return count($this->backoff()) + 1;
+    }
+
+    public function handle(SyncPaymentWithProvider $sync): void
+    {
+        $order = resolve(Order::class)::query()->find($this->orderId);
+
+        if ($order === null) {
+            return;
+        }
+
+        $sync->execute($order, $this->reference);
+    }
+}

--- a/packages/payment/src/Models/PaymentWebhookEvent.php
+++ b/packages/payment/src/Models/PaymentWebhookEvent.php
@@ -5,13 +5,21 @@ declare(strict_types=1);
 namespace Shopper\Payment\Models;
 
 use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Prunable;
+use Shopper\Payment\Database\Factories\PaymentWebhookEventFactory;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Enum\WebhookAction;
 
 /**
  * @property-read int $id
  * @property-read string $driver
  * @property-read string $event_id
- * @property-read ?string $type
+ * @property-read ?WebhookAction $type
+ * @property-read ?string $reference
  * @property-read array<string, mixed>|null $payload
  * @property-read ?CarbonInterface $processed_at
  * @property-read CarbonInterface $created_at
@@ -19,16 +27,109 @@ use Illuminate\Database\Eloquent\Model;
  */
 class PaymentWebhookEvent extends Model
 {
+    /** @use HasFactory<PaymentWebhookEventFactory> */
+    use HasFactory;
+
+    use Prunable;
+
     protected $guarded = [];
+
+    /**
+     * Journalize a delivery exactly once. insertOrIgnore keeps a redelivery
+     * from raising the failed INSERT that would abort a surrounding Postgres
+     * transaction; nothing inserted means the event is already on file.
+     */
+    public static function journal(string $driver, WebhookResult $result): ?static
+    {
+        $now = now();
+
+        $inserted = static::query()->insertOrIgnore([
+            'driver' => $driver,
+            'event_id' => $result->eventId,
+            'type' => $result->action->value,
+            'reference' => $result->reference,
+            'payload' => json_encode($result->toArray()),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        if ($inserted === 0) {
+            return null;
+        }
+
+        return static::query()
+            ->where('driver', $driver)
+            ->where('event_id', $result->eventId)
+            ->firstOrFail();
+    }
 
     public function getTable(): string
     {
         return shopper_table('payment_webhook_events');
     }
 
+    /**
+     * Take the event for application. The conditional update succeeds for
+     * exactly one of two concurrent appliers, and it runs inside the
+     * applier's transaction so a rollback hands the event back untouched.
+     */
+    public function claim(): bool
+    {
+        return $this->newQuery()
+            ->whereKey($this->getKey())
+            ->whereNull('processed_at')
+            ->update(['processed_at' => now()]) === 1;
+    }
+
+    public function isProcessed(): bool
+    {
+        return $this->processed_at !== null;
+    }
+
+    public function toWebhookResult(): WebhookResult
+    {
+        return WebhookResult::fromArray($this->payload ?? []);
+    }
+
+    /**
+     * @return Builder<PaymentWebhookEvent>
+     */
+    public function prunable(): Builder
+    {
+        $days = (int) config('shopper.payment.reconciliation.prune_after_days', 90);
+
+        return static::query()->where('created_at', '<', now()->subDays($days));
+    }
+
+    protected static function newFactory(): PaymentWebhookEventFactory
+    {
+        return PaymentWebhookEventFactory::new();
+    }
+
+    /**
+     * @param  Builder<PaymentWebhookEvent>  $query
+     * @return Builder<PaymentWebhookEvent>
+     */
+    #[Scope]
+    protected function unprocessed(Builder $query): Builder
+    {
+        return $query->whereNull('processed_at');
+    }
+
+    /**
+     * @param  Builder<PaymentWebhookEvent>  $query
+     * @return Builder<PaymentWebhookEvent>
+     */
+    #[Scope]
+    protected function forReference(Builder $query, string $reference): Builder
+    {
+        return $query->where('reference', $reference);
+    }
+
     protected function casts(): array
     {
         return [
+            'type' => WebhookAction::class,
             'payload' => 'array',
             'processed_at' => 'datetime',
         ];

--- a/packages/payment/src/PaymentServiceProvider.php
+++ b/packages/payment/src/PaymentServiceProvider.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Shopper\Payment;
 
 use Closure;
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\ServiceProvider;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\PaymentMethod;
+use Shopper\Payment\Console\ReconcilePaymentsCommand;
 use Shopper\Payment\Facades\Payment;
 use Shopper\Payment\Models\PaymentTransaction;
+use Shopper\Payment\Models\PaymentWebhookEvent;
 use Shopper\Payment\Services\PaymentProcessingService;
 
 final class PaymentServiceProvider extends ServiceProvider
@@ -36,5 +39,17 @@ final class PaymentServiceProvider extends ServiceProvider
         ], 'shopper-config');
 
         Order::resolveRelationUsing('paymentTransactions', fn (Order $order) => $order->hasMany(PaymentTransaction::class, 'order_id'));
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([ReconcilePaymentsCommand::class]);
+        }
+
+        $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
+            if (config('shopper.payment.reconciliation.schedule')) {
+                $schedule->command('shopper:payments:reconcile', ['--pull'])->everyFifteenMinutes();
+            }
+
+            $schedule->command('model:prune', ['--model' => [PaymentWebhookEvent::class]])->daily();
+        });
     }
 }

--- a/packages/payment/src/Services/PaymentProcessingService.php
+++ b/packages/payment/src/Services/PaymentProcessingService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Shopper\Payment\Services;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Shopper\Core\Actions\ReleaseCampaignBudget;
 use Shopper\Core\Enum\OrderStatus;
 use Shopper\Core\Enum\PaymentStatus;
@@ -17,6 +18,7 @@ use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Enum\WebhookAction;
 use Shopper\Payment\Events\PaymentFailed;
 use Shopper\Payment\Exceptions\PaymentException;
 use Shopper\Payment\Facades\Payment;
@@ -73,6 +75,7 @@ final class PaymentProcessingService
             type: TransactionType::Initiate,
             result: $result,
             amount: $order->price_amount,
+            actorId: auth()->id(),
         );
 
         return $result;
@@ -97,6 +100,7 @@ final class PaymentProcessingService
             type: TransactionType::Authorize,
             result: $result,
             amount: $result->amount ?? $order->price_amount,
+            actorId: auth()->id(),
         );
 
         $this->syncPaymentStatus($order, TransactionType::Authorize, $result);
@@ -130,6 +134,7 @@ final class PaymentProcessingService
             type: TransactionType::Capture,
             result: $result,
             amount: $amount ?? $order->price_amount,
+            actorId: auth()->id(),
         );
 
         $this->syncPaymentStatus($order, TransactionType::Capture, $result);
@@ -158,6 +163,7 @@ final class PaymentProcessingService
             type: TransactionType::Refund,
             result: $result,
             amount: $amount,
+            actorId: auth()->id(),
         );
 
         $this->syncPaymentStatus($order, TransactionType::Refund, $result);
@@ -184,6 +190,7 @@ final class PaymentProcessingService
             type: TransactionType::Cancel,
             result: $result,
             amount: $order->price_amount,
+            actorId: auth()->id(),
         );
 
         $this->syncPaymentStatus($order, TransactionType::Cancel, $result);
@@ -191,26 +198,36 @@ final class PaymentProcessingService
         return $result;
     }
 
-    public function processWebhook(string $driver, WebhookResult $result): void
+    /**
+     * Apply what the provider said about a payment to the order it settles.
+     * Runs under the order row lock so the outcome row, the status transition
+     * and the redelivery guard commit together: a duplicate can never slip
+     * between the guard and the insert, and a failure never leaves a capture
+     * journalized on an order that is still unpaid.
+     */
+    public function apply(Order $order, string $driver, WebhookResult $result): void
     {
-        if ($result->isIgnored() || $result->reference === null) {
-            return;
-        }
+        DB::transaction(function () use ($order, $driver, $result): void {
+            /** @var Order $order */
+            $order = resolve(Order::class)::query()->lockForUpdate()->findOrFail($order->getKey());
 
-        $order = $this->findOrderByReference($result->reference);
+            match ($result->action) {
+                WebhookAction::Authorized => $this->recordWebhookOutcome($order, $driver, TransactionType::Authorize, $result),
+                WebhookAction::Captured => $this->recordWebhookOutcome($order, $driver, TransactionType::Capture, $result),
+                WebhookAction::Refunded => $this->processWebhookRefund($order, $driver, $result),
+                WebhookAction::Canceled => $this->processWebhookCancellation($order, $driver, $result),
+                WebhookAction::Failed => $this->processWebhookFailure($order, $driver, $result),
+                WebhookAction::Ignored => null,
+            };
+        });
+    }
 
-        if ($order === null) {
-            return;
-        }
-
-        match ($result->action) {
-            'authorized' => $this->recordWebhookOutcome($order, $driver, TransactionType::Authorize, $result),
-            'captured' => $this->recordWebhookOutcome($order, $driver, TransactionType::Capture, $result),
-            'refunded' => $this->processWebhookRefund($order, $driver, $result),
-            'canceled' => $this->processWebhookCancellation($order, $driver, $result),
-            'failed' => $this->processWebhookFailure($order, $driver, $result),
-            default => null,
-        };
+    public function findOrderByReference(string $reference): ?Order
+    {
+        return PaymentTransaction::query()
+            ->where('reference', $reference)
+            ->latest()
+            ->first()?->order;
     }
 
     /**
@@ -358,11 +375,12 @@ final class PaymentProcessingService
         TransactionType $type,
         PaymentResult $result,
         int $amount,
+        ?int $actorId = null,
     ): void {
         PaymentTransaction::query()->create([
             'order_id' => $order->id,
             'payment_method_id' => $paymentMethod->id,
-            'user_id' => auth()->id(),
+            'user_id' => $actorId,
             'driver' => $driverCode,
             'type' => $type,
             'status' => $result->success ? TransactionStatus::Success : TransactionStatus::Failed,
@@ -374,23 +392,36 @@ final class PaymentProcessingService
         ]);
     }
 
-    private function findOrderByReference(string $reference): ?Order
+    /**
+     * A provider settles a reference once: a second successful authorize,
+     * capture or cancel for the same payment reference is a redelivery, and
+     * a second refund under the same refund id is the webhook confirming a
+     * refund already journalized. Either duplicate would inflate a total the
+     * refund ceiling is computed from.
+     */
+    private function alreadyRecorded(Order $order, TransactionType $type, ?string $reference): bool
     {
+        if ($reference === null) {
+            return false;
+        }
+
         return PaymentTransaction::query()
+            ->where('order_id', $order->getKey())
+            ->where('type', $type)
+            ->where('status', TransactionStatus::Success)
             ->where('reference', $reference)
-            ->latest()
-            ->first()?->order;
+            ->exists();
     }
 
     private function recordWebhookOutcome(Order $order, string $driver, TransactionType $type, WebhookResult $result): void
     {
-        $paymentResult = new PaymentResult(
-            success: true,
-            status: $result->action,
-            reference: $result->reference,
-            amount: $result->amount,
-            data: $result->data,
-        );
+        $reference = $type === TransactionType::Refund ? $result->refundId() : $result->reference;
+
+        if ($this->alreadyRecorded($order, $type, $reference)) {
+            return;
+        }
+
+        $paymentResult = $result->toPaymentResult();
 
         $this->recordTransaction(
             order: $order,
@@ -416,8 +447,18 @@ final class PaymentProcessingService
         $this->cancelOrder($order);
     }
 
+    /**
+     * A failed attempt is not the provider's last word: the intent stays
+     * open for the customer to retry, so the order stays pending with its
+     * stock reserved, and shopper:orders:reclaim cancels it if no payment
+     * ever lands. A failure reported after the payment settled is noise.
+     */
     private function processWebhookFailure(Order $order, string $driver, WebhookResult $result): void
     {
+        if ($order->payment_status !== PaymentStatus::Pending) {
+            return;
+        }
+
         $message = $result->data['failure_message'] ?? null;
 
         $paymentResult = PaymentResult::failed(
@@ -434,10 +475,7 @@ final class PaymentProcessingService
             amount: $result->amount ?? $order->price_amount,
         );
 
-        // Emits PaymentFailed; the failed result leaves the payment status
-        // untouched, then the order is cancelled to release reserved stock.
         $this->syncPaymentStatus($order, TransactionType::Capture, $paymentResult);
-        $this->cancelOrder($order);
     }
 
     private function cancelOrder(Order $order): void

--- a/packages/stripe/src/StripeDriver.php
+++ b/packages/stripe/src/StripeDriver.php
@@ -9,6 +9,7 @@ use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Drivers\Driver;
 use Shopper\Payment\Enum\PaymentMode;
+use Shopper\Payment\Enum\WebhookAction;
 use Shopper\Stripe\Exceptions\StripeException;
 use Stripe\Exception\ApiErrorException;
 use Stripe\Exception\SignatureVerificationException;
@@ -53,6 +54,11 @@ final class StripeDriver extends Driver
             str_starts_with($this->secretKey, 'sk_live_') => PaymentMode::Live,
             default => null,
         };
+    }
+
+    public function supportsRetrieval(): bool
+    {
+        return true;
     }
 
     public function publishableKey(): string
@@ -244,21 +250,21 @@ final class StripeDriver extends Driver
 
         return match ($event->type) {
             'payment_intent.amount_capturable_updated' => new WebhookResult(
-                action: 'authorized',
+                action: WebhookAction::Authorized,
                 reference: $object->id,
                 amount: $object->amount_capturable ?? $object->amount,
                 data: ['stripe_event' => $event->type],
                 eventId: $event->id,
             ),
             'payment_intent.succeeded' => new WebhookResult(
-                action: 'captured',
+                action: WebhookAction::Captured,
                 reference: $object->id,
                 amount: $object->amount_received ?? $object->amount,
                 data: ['stripe_event' => $event->type],
                 eventId: $event->id,
             ),
             'payment_intent.payment_failed' => new WebhookResult(
-                action: 'failed',
+                action: WebhookAction::Failed,
                 reference: $object->id,
                 amount: $object->amount,
                 data: [
@@ -268,19 +274,21 @@ final class StripeDriver extends Driver
                 eventId: $event->id,
             ),
             'payment_intent.canceled' => new WebhookResult(
-                action: 'canceled',
+                action: WebhookAction::Canceled,
                 reference: $object->id,
                 amount: $object->amount,
                 data: ['stripe_event' => $event->type],
                 eventId: $event->id,
             ),
-            'charge.refunded' => new WebhookResult(
-                action: 'refunded',
-                reference: $object->payment_intent,
-                amount: $object->amount_refunded,
-                data: ['stripe_event' => $event->type],
-                eventId: $event->id,
-            ),
+            'refund.created', 'refund.updated' => $object->status === 'succeeded'
+                ? new WebhookResult(
+                    action: WebhookAction::Refunded,
+                    reference: $object->payment_intent,
+                    amount: $object->amount,
+                    data: ['stripe_event' => $event->type, 'refund_id' => $object->id],
+                    eventId: $event->id,
+                )
+                : WebhookResult::ignored(),
             default => WebhookResult::ignored(),
         };
     }

--- a/tests/Api/Feature/PaymentReconciliationTest.php
+++ b/tests/Api/Feature/PaymentReconciliationTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Exceptions;
+use Shopper\Cart\Models\Cart;
+use Shopper\Core\Enum\AddressType;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Events\Orders\OrderPaid;
+use Shopper\Core\Models\Carrier;
+use Shopper\Core\Models\CarrierOption;
+use Shopper\Core\Models\Country;
+use Shopper\Core\Models\Inventory;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\PaymentMethod;
+use Shopper\Core\Models\Product;
+use Shopper\Core\Models\Zone;
+use Shopper\Payment\Actions\SettlePayment;
+use Shopper\Payment\DataTransferObjects\WebhookResult;
+use Shopper\Payment\Enum\TransactionStatus;
+use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Enum\WebhookAction;
+use Shopper\Payment\Facades\Payment;
+use Shopper\Payment\Models\PaymentTransaction;
+use Shopper\Payment\Models\PaymentWebhookEvent;
+use Tests\Api\Stubs\FakePaymentDriver;
+
+uses(Tests\Api\TestCase::class);
+
+/**
+ * @param  array<string, mixed>  $data
+ */
+function earlyEvent(WebhookAction $action, string $reference, string $eventId, int $amount = 3200, array $data = []): PaymentWebhookEvent
+{
+    return PaymentWebhookEvent::factory()
+        ->fromResult(new WebhookResult(action: $action, reference: $reference, amount: $amount, data: $data, eventId: $eventId))
+        ->create(['driver' => 'fake']);
+}
+
+function transactionsOf(Order $order, TransactionType $type, TransactionStatus $status): int
+{
+    return PaymentTransaction::query()
+        ->where('order_id', $order->id)
+        ->where('type', $type)
+        ->where('status', $status)
+        ->count();
+}
+
+beforeEach(function (): void {
+    setupCurrencies();
+
+    $driver = $this->driver = new FakePaymentDriver;
+    Payment::extend('fake', fn (): FakePaymentDriver => $driver);
+
+    $country = Country::factory()->create(['cca2' => 'US']);
+    $zone = Zone::factory()->create(['is_enabled' => true]);
+    $zone->countries()->attach($country);
+
+    $carrier = Carrier::factory()->create(['name' => 'Main Carrier', 'slug' => 'main-carrier', 'is_enabled' => true]);
+    $zone->carriers()->attach($carrier);
+
+    $option = CarrierOption::factory()->create([
+        'name' => 'Standard',
+        'price' => 700,
+        'is_enabled' => true,
+        'carrier_id' => $carrier->id,
+        'zone_id' => $zone->id,
+    ]);
+
+    $method = PaymentMethod::factory()->create(['title' => 'Card', 'is_enabled' => true, 'driver' => 'fake']);
+    $method->zones()->attach($zone);
+
+    $this->inventory = Inventory::factory()->create(['is_default' => true, 'priority' => 0]);
+    $this->product = Product::factory()->standard()->publish()->create();
+    $this->product->mutateStock($this->inventory->id, 100);
+
+    $this->cart = Cart::factory()->create([
+        'currency_code' => 'USD',
+        'email' => 'john@example.com',
+        'zone_id' => $zone->id,
+    ]);
+
+    $this->cart->lines()->create([
+        'purchasable_type' => $this->product->getMorphClass(),
+        'purchasable_id' => $this->product->id,
+        'quantity' => 1,
+        'unit_price_amount' => 2500,
+    ]);
+
+    $this->cart->addresses()->create([
+        'type' => AddressType::Shipping,
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'address_1' => '1 Main Street',
+        'city' => 'New York',
+        'postal_code' => '10001',
+    ]);
+
+    $this->cart->update([
+        'shipping_option_id' => "main-carrier:{$option->public_id}",
+        'shipping_amount' => $option->price,
+        'payment_method_id' => $method->id,
+    ]);
+
+    $this->completeUrl = "/store/carts/{$this->cart->public_id}/complete";
+
+    $this->reference = $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")
+        ->assertCreated()
+        ->json('data.id');
+});
+
+it('settles a captured event that arrived before the cart was completed', function (): void {
+    $event = earlyEvent(WebhookAction::Captured, $this->reference, 'evt_early_capture');
+
+    $orderId = $this->postJson($this->completeUrl)
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.payment_status', PaymentStatus::Paid->value)
+        ->json('data.id');
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->payment_status)->toBe(PaymentStatus::Paid)
+        ->and(transactionsOf($order, TransactionType::Initiate, TransactionStatus::Pending))->toBe(1)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(1)
+        ->and($event->refresh()->isProcessed())->toBeTrue()
+        ->and($this->driver->retrievals)->toBe(0);
+});
+
+it('records an early failed attempt without cancelling the order', function (): void {
+    earlyEvent(WebhookAction::Failed, $this->reference, 'evt_early_failed', data: ['failure_message' => 'card_declined']);
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->status)->toBe(OrderStatus::New)
+        ->and($order->payment_status)->toBe(PaymentStatus::Pending)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Failed))->toBe(1)
+        ->and($this->product->getStock())->toBe(99)
+        ->and($this->driver->retrievals)->toBe(1);
+});
+
+it('ignores a failed attempt superseded by a later capture', function (): void {
+    $declined = earlyEvent(WebhookAction::Failed, $this->reference, 'evt_declined', data: ['failure_message' => 'card_declined']);
+    $recovered = earlyEvent(WebhookAction::Captured, $this->reference, 'evt_recovered');
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->status)->toBe(OrderStatus::New)
+        ->and($order->payment_status)->toBe(PaymentStatus::Paid)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(1)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Failed))->toBe(0)
+        ->and($declined->refresh()->isProcessed())->toBeTrue()
+        ->and($recovered->refresh()->isProcessed())->toBeTrue()
+        ->and($this->product->getStock())->toBe(99);
+});
+
+it('voids the payment and cancels the order on an early canceled event', function (): void {
+    earlyEvent(WebhookAction::Canceled, $this->reference, 'evt_early_canceled');
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->status)->toBe(OrderStatus::Cancelled)
+        ->and($order->payment_status)->toBe(PaymentStatus::Voided)
+        ->and(transactionsOf($order, TransactionType::Cancel, TransactionStatus::Success))->toBe(1);
+});
+
+it('pulls the provider state when no early event settled the payment', function (): void {
+    $this->driver->retrievedStatus = 'captured';
+
+    $orderId = $this->postJson($this->completeUrl)
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.payment_status', PaymentStatus::Paid->value)
+        ->json('data.id');
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(1)
+        ->and($this->driver->retrievals)->toBe(1);
+});
+
+it('does not pull the provider when the setting is off', function (): void {
+    config()->set('shopper.payment.reconciliation.pull_on_completion', false);
+    $this->driver->retrievedStatus = 'captured';
+
+    $this->postJson($this->completeUrl)
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.payment_status', PaymentStatus::Pending->value);
+
+    expect($this->driver->retrievals)->toBe(0);
+});
+
+it('leaves the payment pending when the provider reports a non terminal state', function (): void {
+    $this->driver->retrievedStatus = 'processing';
+
+    $orderId = $this->postJson($this->completeUrl)
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.payment_status', PaymentStatus::Pending->value)
+        ->json('data.id');
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(0)
+        ->and($this->driver->retrievals)->toBe(1);
+});
+
+it('never fails the completion when the provider is unreachable', function (): void {
+    Exceptions::fake();
+    $this->driver->throwOnRetrieve = true;
+
+    $this->postJson($this->completeUrl)
+        ->assertCreated()
+        ->assertJsonPath('data.attributes.payment_status', PaymentStatus::Pending->value);
+
+    Exceptions::assertReported(RuntimeException::class);
+});
+
+it('keeps an event applied when a listener fails after the commit', function (): void {
+    Exceptions::fake();
+    Event::listen(OrderPaid::class, function (): void {
+        throw new RuntimeException('Listener exploded.');
+    });
+
+    $event = earlyEvent(WebhookAction::Captured, $this->reference, 'evt_exploding');
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+
+    Exceptions::assertReported(RuntimeException::class);
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->payment_status)->toBe(PaymentStatus::Paid)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(1)
+        ->and($event->refresh()->isProcessed())->toBeTrue();
+});
+
+it('hands the event back when its application rolls back', function (): void {
+    config()->set('shopper.payment.reconciliation.pull_on_completion', false);
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+    $order->update(['payment_method_id' => null]);
+
+    $event = earlyEvent(WebhookAction::Captured, $this->reference, 'evt_rolled_back');
+
+    expect(fn () => resolve(SettlePayment::class)->execute($this->reference))->toThrow(TypeError::class)
+        ->and($event->refresh()->isProcessed())->toBeFalse()
+        ->and($order->refresh()->payment_status)->toBe(PaymentStatus::Pending)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(0);
+});
+
+it('records a single capture when the webhook redelivers what the pull already applied', function (): void {
+    $this->driver->retrievedStatus = 'captured';
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+
+    $this->postJson('/store/webhooks/fake', [
+        'action' => 'captured',
+        'reference' => $this->reference,
+        'amount' => 3200,
+        'event_id' => 'evt_late_capture',
+    ])->assertOk();
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->payment_status)->toBe(PaymentStatus::Paid)
+        ->and(transactionsOf($order, TransactionType::Capture, TransactionStatus::Success))->toBe(1)
+        ->and(PaymentWebhookEvent::query()->where('event_id', 'evt_late_capture')->firstOrFail()->isProcessed())->toBeTrue();
+});
+
+it('keeps an early event unprocessed until its order exists', function (): void {
+    $this->postJson('/store/webhooks/fake', [
+        'action' => 'captured',
+        'reference' => $this->reference,
+        'amount' => 3200,
+        'event_id' => 'evt_orphan',
+    ])->assertOk()->assertJson(['received' => true]);
+
+    $event = PaymentWebhookEvent::query()->where('event_id', 'evt_orphan')->firstOrFail();
+
+    expect($event->isProcessed())->toBeFalse()
+        ->and($event->reference)->toBe($this->reference);
+});
+
+it('settles pending payments from the ledger through the reconcile command', function (): void {
+    config()->set('shopper.payment.reconciliation.pull_on_completion', false);
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+
+    $slipped = earlyEvent(WebhookAction::Captured, $this->reference, 'evt_slipped');
+    $nobody = earlyEvent(WebhookAction::Captured, 'pi_nobody', 'evt_nobody');
+
+    $this->artisan('shopper:payments:reconcile')
+        ->expectsOutputToContain('1 payment settled')
+        ->expectsOutputToContain('1 event still without an order')
+        ->assertSuccessful();
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->payment_status)->toBe(PaymentStatus::Paid)
+        ->and($slipped->refresh()->isProcessed())->toBeTrue()
+        ->and($nobody->refresh()->isProcessed())->toBeFalse();
+});
+
+it('pulls the provider for orders pending past the threshold', function (): void {
+    config()->set('shopper.payment.reconciliation.pull_on_completion', false);
+
+    $orderId = $this->postJson($this->completeUrl)->assertCreated()->json('data.id');
+    $this->driver->retrievedStatus = 'captured';
+
+    $this->artisan('shopper:payments:reconcile', ['--pull' => true])->assertSuccessful();
+
+    $order = Order::query()->where('public_id', $orderId)->firstOrFail();
+
+    expect($order->payment_status)->toBe(PaymentStatus::Pending)
+        ->and($this->driver->retrievals)->toBe(0);
+
+    $this->travel(16)->minutes();
+
+    $this->artisan('shopper:payments:reconcile', ['--pull' => true])
+        ->expectsOutputToContain('1 pending payment queued')
+        ->assertSuccessful();
+
+    expect($order->refresh()->payment_status)->toBe(PaymentStatus::Paid)
+        ->and($this->driver->retrievals)->toBe(1);
+});

--- a/tests/Api/Feature/PaymentWebhookTest.php
+++ b/tests/Api/Feature/PaymentWebhookTest.php
@@ -67,7 +67,8 @@ it('advances the order to Paid on a captured event', function (): void {
     ])->assertOk()->assertJson(['received' => true]);
 
     expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Paid)
-        ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Capture)->count())->toBe(1);
+        ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Capture)->count())->toBe(1)
+        ->and(PaymentWebhookEvent::query()->where('event_id', 'evt_capture_1')->firstOrFail()->isProcessed())->toBeTrue();
 });
 
 it('is idempotent: a redelivered event id is not processed twice', function (): void {

--- a/tests/Api/Stubs/FakePaymentDriver.php
+++ b/tests/Api/Stubs/FakePaymentDriver.php
@@ -8,10 +8,15 @@ use RuntimeException;
 use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Drivers\Driver;
+use Shopper\Payment\Enum\WebhookAction;
 
 final class FakePaymentDriver extends Driver
 {
     public bool $failRetrieve = false;
+
+    public bool $throwOnRetrieve = false;
+
+    public ?string $retrievedStatus = null;
 
     public int $initiations = 0;
 
@@ -85,16 +90,34 @@ final class FakePaymentDriver extends Driver
         }
 
         return new WebhookResult(
-            action: (string) ($payload['action'] ?? 'ignored'),
+            action: WebhookAction::tryFrom((string) ($payload['action'] ?? '')) ?? WebhookAction::Ignored,
             reference: isset($payload['reference']) ? (string) $payload['reference'] : null,
             amount: isset($payload['amount']) ? (int) $payload['amount'] : null,
             eventId: isset($payload['event_id']) ? (string) $payload['event_id'] : null,
         );
     }
 
+    public function supportsRetrieval(): bool
+    {
+        return true;
+    }
+
     public function retrievePayment(string $reference): PaymentResult
     {
         $this->retrievals++;
+
+        if ($this->throwOnRetrieve) {
+            throw new RuntimeException('Provider unreachable.');
+        }
+
+        if ($this->retrievedStatus !== null) {
+            return new PaymentResult(
+                success: true,
+                status: $this->retrievedStatus,
+                reference: $reference,
+                amount: $this->lastAmount,
+            );
+        }
 
         if ($this->failRetrieve) {
             return new PaymentResult(

--- a/tests/Payment/PaymentWebhookEventTest.php
+++ b/tests/Payment/PaymentWebhookEventTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Shopper\Payment\Models\PaymentWebhookEvent;
+
+uses(Tests\Core\TestCase::class);
+
+it('claims a webhook event exactly once', function (): void {
+    $event = PaymentWebhookEvent::factory()->create();
+
+    expect($event->claim())->toBeTrue()
+        ->and($event->claim())->toBeFalse()
+        ->and($event->refresh()->isProcessed())->toBeTrue();
+});

--- a/tests/Payment/PaymentWebhookProcessingTest.php
+++ b/tests/Payment/PaymentWebhookProcessingTest.php
@@ -172,7 +172,7 @@ describe('PaymentWebhookProcessingTest', function (): void {
         }
 
         expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::PartiallyRefunded)
-            ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Refund)->sum('amount'))->toBe(2000);
+            ->and((int) PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Refund)->sum('amount'))->toBe(2000);
     });
 
     it('does not count an admin refund twice when its webhook confirms it', function (): void {

--- a/tests/Payment/PaymentWebhookProcessingTest.php
+++ b/tests/Payment/PaymentWebhookProcessingTest.php
@@ -13,12 +13,13 @@ use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderItem;
 use Shopper\Core\Models\PaymentMethod;
 use Shopper\Core\Models\Product;
+use Shopper\Payment\Actions\IngestPaymentEvent;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Enum\WebhookAction;
 use Shopper\Payment\Events\PaymentFailed;
 use Shopper\Payment\Models\PaymentTransaction;
-use Shopper\Payment\Services\PaymentProcessingService;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Core\TestCase::class);
@@ -48,13 +49,13 @@ beforeEach(function (): void {
         'reference' => 'pi_123',
     ]);
 
-    $this->service = resolve(PaymentProcessingService::class);
+    $this->ingest = resolve(IngestPaymentEvent::class);
 });
 
 describe('PaymentWebhookProcessingTest', function (): void {
     it('advances the order to `Paid` on a captured event', function (): void {
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_1',
@@ -72,8 +73,8 @@ describe('PaymentWebhookProcessingTest', function (): void {
     });
 
     it('advances the order to `Authorized` on an authorized event', function (): void {
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'authorized',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Authorized,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_2',
@@ -83,15 +84,15 @@ describe('PaymentWebhookProcessingTest', function (): void {
     });
 
     it('marks the order `PartiallyRefunded` then `Refunded` as refunds accumulate', function (): void {
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_capture',
         ));
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'refunded',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Refunded,
             reference: 'pi_123',
             amount: 2000,
             eventId: 'evt_3',
@@ -99,8 +100,8 @@ describe('PaymentWebhookProcessingTest', function (): void {
 
         expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::PartiallyRefunded);
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'refunded',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Refunded,
             reference: 'pi_123',
             amount: 3000,
             eventId: 'evt_4',
@@ -109,22 +110,24 @@ describe('PaymentWebhookProcessingTest', function (): void {
         expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
     });
 
-    it('cancels the order and dispatches `PaymentFailed` on a failed event', function (): void {
+    it('records a failed attempt and dispatches `PaymentFailed` without cancelling the order', function (): void {
         Event::fake([PaymentFailed::class]);
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'failed',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Failed,
             reference: 'pi_123',
             amount: 5000,
             data: ['failure_message' => 'card_declined'],
             eventId: 'evt_5',
         ));
 
-        expect($this->order->refresh()->status)->toBe(OrderStatus::Cancelled);
+        expect($this->order->refresh()->status)->toBe(OrderStatus::New)
+            ->and($this->order->payment_status)->toBe(PaymentStatus::Pending)
+            ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Capture)->where('status', TransactionStatus::Failed)->count())->toBe(1);
         Event::assertDispatched(PaymentFailed::class);
     });
 
-    it('restores reserved stock when a payment fails', function (): void {
+    it('keeps the stock reserved on a failed attempt so the customer can retry', function (): void {
         $inventory = Inventory::factory()->create(['is_default' => true, 'priority' => 0]);
         $product = Product::factory()->standard()->create();
         $product->mutateStock($inventory->id, 10, event: 'Initial');
@@ -139,27 +142,76 @@ describe('PaymentWebhookProcessingTest', function (): void {
         resolve(StockReserver::class)->reserve($product, 3, $this->order, $this->user->id);
         expect($product->getStock())->toBe(7);
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'failed',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Failed,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_6',
         ));
 
-        expect($this->order->refresh()->status)->toBe(OrderStatus::Cancelled)
-            ->and($product->getStock())->toBe(10);
+        expect($this->order->refresh()->status)->toBe(OrderStatus::New)
+            ->and($product->getStock())->toBe(7);
+    });
+
+    it('collapses a redelivered refund onto the refund id', function (): void {
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_refund_capture',
+        ));
+
+        foreach (['evt_refund_a', 'evt_refund_b'] as $eventId) {
+            $this->ingest->execute('fake', new WebhookResult(
+                action: WebhookAction::Refunded,
+                reference: 'pi_123',
+                amount: 2000,
+                data: ['refund_id' => 're_1'],
+                eventId: $eventId,
+            ));
+        }
+
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::PartiallyRefunded)
+            ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Refund)->sum('amount'))->toBe(2000);
+    });
+
+    it('does not count an admin refund twice when its webhook confirms it', function (): void {
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
+            reference: 'pi_123',
+            amount: 5000,
+            eventId: 'evt_admin_capture',
+        ));
+
+        PaymentTransaction::factory()->refund()->create([
+            'order_id' => $this->order->id,
+            'payment_method_id' => $this->method->id,
+            'driver' => 'fake',
+            'amount' => 2000,
+            'reference' => 're_admin',
+        ]);
+
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Refunded,
+            reference: 'pi_123',
+            amount: 2000,
+            data: ['refund_id' => 're_admin'],
+            eventId: 'evt_admin_refund',
+        ));
+
+        expect(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Refund)->count())->toBe(1);
     });
 
     it('keeps a refunded order refunded when a late captured event arrives', function (): void {
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_late_1',
         ));
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'refunded',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Refunded,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_late_2',
@@ -167,14 +219,15 @@ describe('PaymentWebhookProcessingTest', function (): void {
 
         expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_late_3',
         ));
 
-        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded);
+        expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Refunded)
+            ->and(PaymentTransaction::query()->where('order_id', $this->order->id)->where('type', TransactionType::Capture)->count())->toBe(1);
     });
 
     it('keeps a paid order paid when a late failed event arrives', function (): void {
@@ -191,15 +244,15 @@ describe('PaymentWebhookProcessingTest', function (): void {
 
         resolve(StockReserver::class)->reserve($product, 3, $this->order, $this->user->id);
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_ooo_1',
         ));
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'failed',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Failed,
             reference: 'pi_123',
             amount: 5000,
             data: ['failure_message' => 'late failure'],
@@ -214,8 +267,8 @@ describe('PaymentWebhookProcessingTest', function (): void {
     it('dispatches `OrderPaid` when a captured webhook marks the order paid', function (): void {
         Event::fake([OrderPaid::class]);
 
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_123',
             amount: 5000,
             eventId: 'evt_paid_event',
@@ -228,8 +281,8 @@ describe('PaymentWebhookProcessingTest', function (): void {
     });
 
     it('does nothing when no order matches the reference', function (): void {
-        $this->service->processWebhook('fake', new WebhookResult(
-            action: 'captured',
+        $this->ingest->execute('fake', new WebhookResult(
+            action: WebhookAction::Captured,
             reference: 'pi_unknown',
             amount: 5000,
             eventId: 'evt_7',
@@ -240,7 +293,7 @@ describe('PaymentWebhookProcessingTest', function (): void {
     });
 
     it('ignores an ignored webhook result', function (): void {
-        $this->service->processWebhook('fake', WebhookResult::ignored());
+        $this->ingest->execute('fake', WebhookResult::ignored());
 
         expect($this->order->refresh()->payment_status)->toBe(PaymentStatus::Pending);
     });

--- a/tests/Stripe/StripeDriverTest.php
+++ b/tests/Stripe/StripeDriverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Enum\PaymentMode;
+use Shopper\Payment\Enum\WebhookAction;
 use Shopper\Stripe\Exceptions\StripeException;
 use Shopper\Stripe\StripeDriver;
 use Stripe\Exception\InvalidRequestException;
@@ -660,7 +661,7 @@ describe(StripeDriver::class, function (): void {
             $result = $driver->handleWebhook($webhook['payload'], $webhook['headers']);
 
             expect($result)->toBeInstanceOf(WebhookResult::class)
-                ->and($result->action)->toBe('captured')
+                ->and($result->action)->toBe(WebhookAction::Captured)
                 ->and($result->reference)->toBe('pi_test_123')
                 ->and($result->amount)->toBe(5000)
                 ->and($result->data['stripe_event'])->toBe('payment_intent.succeeded');
@@ -677,7 +678,7 @@ describe(StripeDriver::class, function (): void {
 
             $result = $driver->handleWebhook($webhook['payload'], $webhook['headers']);
 
-            expect($result->action)->toBe('failed')
+            expect($result->action)->toBe(WebhookAction::Failed)
                 ->and($result->reference)->toBe('pi_test_456')
                 ->and($result->amount)->toBe(3000)
                 ->and($result->data['failure_message'])->toBe('Your card was declined.');
@@ -693,25 +694,42 @@ describe(StripeDriver::class, function (): void {
 
             $result = $driver->handleWebhook($webhook['payload'], $webhook['headers']);
 
-            expect($result->action)->toBe('canceled')
+            expect($result->action)->toBe(WebhookAction::Canceled)
                 ->and($result->reference)->toBe('pi_test_789')
                 ->and($result->amount)->toBe(2000);
         });
 
-        it('handles `charge.refunded` event', function (): void {
+        it('handles a succeeded `refund.created` event with the refund amount and id', function (): void {
             $driver = createDriver();
-            $webhook = webhookPayload('charge.refunded', [
-                'id' => 'ch_test_123',
-                'object' => 'charge',
+            $webhook = webhookPayload('refund.created', [
+                'id' => 're_test_123',
+                'object' => 'refund',
                 'payment_intent' => 'pi_test_123',
-                'amount_refunded' => 2500,
+                'amount' => 2500,
+                'status' => 'succeeded',
             ]);
 
             $result = $driver->handleWebhook($webhook['payload'], $webhook['headers']);
 
-            expect($result->action)->toBe('refunded')
+            expect($result->action)->toBe(WebhookAction::Refunded)
                 ->and($result->reference)->toBe('pi_test_123')
-                ->and($result->amount)->toBe(2500);
+                ->and($result->amount)->toBe(2500)
+                ->and($result->refundId())->toBe('re_test_123');
+        });
+
+        it('ignores a refund that has not succeeded yet', function (): void {
+            $driver = createDriver();
+            $webhook = webhookPayload('refund.updated', [
+                'id' => 're_test_123',
+                'object' => 'refund',
+                'payment_intent' => 'pi_test_123',
+                'amount' => 2500,
+                'status' => 'pending',
+            ]);
+
+            $result = $driver->handleWebhook($webhook['payload'], $webhook['headers']);
+
+            expect($result->isIgnored())->toBeTrue();
         });
 
         it('returns ignored result for unknown events', function (): void {


### PR DESCRIPTION
## What

In the Store API flow the provider confirms the payment in the browser before `POST /store/carts/{id}/complete` creates the order, so `payment_intent.succeeded` usually lands first. The webhook controller journalized the event as processed before applying it, `processWebhook()` returned when no order matched the reference, and completion never looked at the ledger. The order stayed `payment_status = pending` forever while every webhook answered 200, and a Stripe redelivery was rejected as a duplicate.

### Webhook ledger as a transactional inbox

- `IngestPaymentEvent` journalizes the event unprocessed (`processed_at` null) and hands it to `ApplyPaymentEvent`, which resolves the order, then claims the row with a conditional update inside the same transaction that applies it. A rollback hands the event back to the ledger, a redelivery collapses on the unique `(driver, event_id)` key, and a listener failing after commit no longer releases anything.
- `PaymentProcessingService::apply()` is the single write path: transactional, order row locked, deduplicated by payment reference or refund id. Webhook actions move from strings to the `WebhookAction` enum.
- New `reference` column on `sh_payment_webhook_events`, indexed with `processed_at`. The migration backfills existing rows and resets `processed_at` for events that predate any transaction of their reference, so the previously swallowed events become replayable.

### Catching up at completion

- `CompleteCartAction` replays the stored events for its payment reference through `SettlePayment`, ordered by action precedence, then queues `SyncPendingPaymentJob` when the payment is still pending. The job asks the provider through `retrievePayment()` and applies the terminal state. Nothing calls the provider inline in the request.
- `shopper:payments:reconcile --pull` runs every fifteen minutes: it replays orphaned events whose order now exists and queues a provider check for every payment still awaiting confirmation. The ledger is pruned daily through `model:prune`.
- `PaymentDriver` gains `supportsRetrieval()`, true for Stripe, false by default.
- Configurable through `shopper.payment.reconciliation` (pull on completion, schedule, queue, backoff, retention).

### Domain rules

- A `failed` webhook records the failed attempt and dispatches `PaymentFailed`, it no longer cancels the order: the customer may still retry on the same intent. `shopper.orders.reclaim_pending_after_hours` now defaults to 24 hours so unpaid orders release their stock. `Order::isAwaitingPayment()` and the `awaitingPayment()` scope are shared with the reclaim command.
- Stripe refunds are ingested from `refund.created` and `refund.updated` (status `succeeded`) with the amount of that refund and its id, instead of the cumulative `charge.refunded`. A refund issued from the admin and its confirming webhook collapse onto one transaction.
- Every transaction written from a provider event carries no actor; outgoing operations record the authenticated user. `PaymentFailed` is dispatched after commit like the other order events.

## Breaking changes

- `WebhookResult::$action` is typed `WebhookAction` instead of `string`. Drivers must return the enum cases.
- `PaymentDriver` gains `supportsRetrieval(): bool`. The base `Driver` returns `false`.
- `PaymentProcessingService::processWebhook()` is removed. Use `IngestPaymentEvent` for a raw provider event or `PaymentProcessingService::apply()` when the order is already known.
- The Stripe driver no longer handles `charge.refunded`. Enable `refund.created` and `refund.updated` on the Stripe webhook endpoint.
- A published `shopper/payment.php` config needs the `reconciliation` block, otherwise the scheduled reconcile stays off.
- `shopper.orders.reclaim_pending_after_hours` defaults to 24 instead of null; set it to null to keep unpaid orders indefinitely.
- `sh_payment_webhook_events` gains a `reference` column. Run the migrations.
