### PR TITLE
fix(packages): require sibling packages at self.version

### DIFF
--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -11,11 +11,11 @@
   "require": {
     "php": "^8.3",
     "laravel/prompts": "^0.3.16",
-    "shopper/cart": "*",
-    "shopper/core": "*",
-    "shopper/http": "*",
-    "shopper/payment": "*",
-    "shopper/shipping": "*",
+    "shopper/cart": "self.version",
+    "shopper/core": "self.version",
+    "shopper/http": "self.version",
+    "shopper/payment": "self.version",
+    "shopper/shipping": "self.version",
     "spatie/laravel-medialibrary": "^11.5",
     "spatie/laravel-query-builder": "^7.3",
     "timacdonald/json-api": "^1.0@beta"

--- a/packages/cart/composer.json
+++ b/packages/cart/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.3",
-    "shopper/core": "*"
+    "shopper/core": "self.version"
   },
   "autoload": {
     "psr-4": {

--- a/packages/http/composer.json
+++ b/packages/http/composer.json
@@ -11,7 +11,7 @@
   "require": {
     "php": "^8.3",
     "laravel/sanctum": "^4.0",
-    "shopper/core": "*"
+    "shopper/core": "self.version"
   },
   "autoload": {
     "psr-4": {

--- a/packages/payment/composer.json
+++ b/packages/payment/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.3",
-    "shopper/core": "*"
+    "shopper/core": "self.version"
   },
   "autoload": {
     "psr-4": {

--- a/packages/shipping/composer.json
+++ b/packages/shipping/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.3",
-    "shopper/core": "*",
+    "shopper/core": "self.version",
     "ivanmitrikeski/laravel-shipping": "^1.0"
   },
   "autoload": {

--- a/packages/stripe/composer.json
+++ b/packages/stripe/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "require": {
     "php": "^8.3",
-    "shopper/payment": "*",
+    "shopper/payment": "self.version",
     "stripe/stripe-php": "^19.0"
   },
   "autoload": {


### PR DESCRIPTION
The split packages required each other with `"*"`. `shopper/framework` already used `self.version`, the six others did not:

```
shopper/api       cart, core, http, payment, shipping  ->  "*"
shopper/cart      core                                 ->  "*"
shopper/http      core                                 ->  "*"
shopper/payment   core                                 ->  "*"
shopper/shipping  core                                 ->  "*"
shopper/stripe    payment                              ->  "*"
```

A fresh install resolves fine, since Composer picks the highest version available. The upgrade path does not. An application pinned to `shopper/core: ^2.11` that runs `composer require shopper/api:^3.0` gets:

```
- Locking shopper/api (3.0.0)

shopper/api  => 3.0.0
shopper/core => 2.11.2
```

`shopper/api` 3.x installed on top of `shopper/core` 2.x, no warning, because `"*"` is satisfied. That is the exact path every 2.x store takes to reach 3.0.

With `self.version`, Composer refuses and names the way out:

```
Problem 1
  - shopper/api 3.0.0 requires shopper/core 3.0.0 -> found shopper/core[3.0.0]
    but it conflicts with your root composer.json require (^2.11).
Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and
removals for packages currently locked to specific versions.
```

and the coordinated upgrade goes through:

```
$ composer require shopper/core:^3.0 shopper/payment:^3.0 shopper/api:^3.0 -W
  - Upgrading shopper/core (2.11.2 => 3.0.0)
  - Upgrading shopper/payment (2.11.2 => 3.0.0)
  - Locking shopper/api (3.0.0)
```

This is what Filament and Lunar do on their own split packages, and Vanilo and Sylius use pinned ranges for the same reason. No sibling package in the dependency tree uses `"*"`.

`self.version` makes the suite lockstep, which the release process already guarantees: `monorepo-split.yml` tags all twelve packages on every tag.

Nothing changes locally or in CI. The root `composer.json` declares no `repositories`, so `packages/*/composer.json` is never read during resolution here, and the packages are covered by the root `replace`. The change only affects the packages published after the split.

The migration guide will need a line saying the whole `shopper/*` line moves in one command instead of package by package.