### PR TITLE
feat(http): answer cross origin requests on the store routes

### DIFF
--- a/packages/http/src/HttpServiceProvider.php
+++ b/packages/http/src/HttpServiceProvider.php
@@ -59,11 +59,22 @@ final class HttpServiceProvider extends PackageServiceProvider
             'shopper-config',
         );
 
+        $this->registerCorsPaths();
         $this->registerRateLimiters();
         $this->registerMiddleware();
         $this->registerExceptionRenderer();
         $this->registerZoneCacheInvalidation();
         $this->registerChannelCacheInvalidation();
+    }
+
+    private function registerCorsPaths(): void
+    {
+        $path = mb_trim($this->app->make(ShopperApiRouter::class)->prefix(), '/').'/*';
+        $paths = (array) config('cors.paths', []);
+
+        if (! in_array($path, $paths, true)) {
+            config(['cors.paths' => [...$paths, $path]]);
+        }
     }
 
     private function registerChannelCacheInvalidation(): void

--- a/tests/Http/Feature/StoreGroupTest.php
+++ b/tests/Http/Feature/StoreGroupTest.php
@@ -23,6 +23,19 @@ it('prefixes store routes and forces a JSON:API content type', function (): void
         ->assertJson(['ok' => true]);
 });
 
+it('answers cross origin preflight requests on store routes', function (): void {
+    ShopperApi::store(function (): void {
+        Route::get('/ping', fn () => response()->json(['ok' => true]));
+    });
+
+    $this->options('/store/ping', [], [
+        'Origin' => 'https://shop.example',
+        'Access-Control-Request-Method' => 'GET',
+    ])
+        ->assertNoContent()
+        ->assertHeader('Access-Control-Allow-Origin', '*');
+});
+
 it('binds the resolved zone onto the request', function (): void {
     $zone = Zone::factory()->make(['code' => 'eu']);
 


### PR DESCRIPTION
## Summary

Laravel's `HandleCors` middleware only answers cross origin requests on the paths listed in `cors.paths`, and the default list is `api/*` and `sanctum/csrf-cookie`. The Store API lives under its own prefix, `store` by default, so a storefront served from another origin never received the CORS headers and every preflight failed.

`shopper/http` now appends `{prefix}/*` to `cors.paths` when it boots, using the configured `shopper.http.prefix`, and skips it when the application already lists the path. Origins, methods and headers stay under the application's own CORS configuration.
