### PR TITLE
feat(api): attach the cart at authentication, expire tokens and code every error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -574,6 +574,16 @@
         }
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.148.0.tgz",
+      "integrity": "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/oxc-project"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.4.tgz",
@@ -894,6 +904,286 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz",
+      "integrity": "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz",
+      "integrity": "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz",
+      "integrity": "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz",
+      "integrity": "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz",
+      "integrity": "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz",
+      "integrity": "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz",
+      "integrity": "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz",
+      "integrity": "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz",
+      "integrity": "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz",
+      "integrity": "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz",
+      "integrity": "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz",
+      "integrity": "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz",
+      "integrity": "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz",
+      "integrity": "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz",
+      "integrity": "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@ryangjchandler/alpine-tooltip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@ryangjchandler/alpine-tooltip/-/alpine-tooltip-2.0.1.tgz",
@@ -989,6 +1279,13 @@
       "version": "13.3.0",
       "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
       "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tailwindcss/cli": {
@@ -1293,6 +1590,31 @@
         "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1326,6 +1648,99 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/adjust-sourcemap-loader": {
       "version": "4.0.0",
@@ -1391,6 +1806,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-function": {
@@ -1608,6 +2033,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -1988,6 +2423,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2111,6 +2553,44 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/focus-trap": {
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
@@ -2149,6 +2629,21 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -3392,9 +3887,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3514,6 +4009,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
@@ -3605,6 +4114,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3613,9 +4129,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3671,9 +4187,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "dev": true,
       "funding": [
         {
@@ -3691,7 +4207,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4028,6 +4544,40 @@
         "node": ">=12"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
+      "integrity": "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.148.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.7",
+        "@rolldown/binding-android-arm64": "1.2.7",
+        "@rolldown/binding-darwin-arm64": "1.2.7",
+        "@rolldown/binding-darwin-x64": "1.2.7",
+        "@rolldown/binding-freebsd-x64": "1.2.7",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.7",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.7",
+        "@rolldown/binding-linux-arm64-musl": "1.2.7",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.7",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-gnu": "1.2.7",
+        "@rolldown/binding-linux-x64-musl": "1.2.7",
+        "@rolldown/binding-openharmony-arm64": "1.2.7",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.7",
+        "@rolldown/binding-win32-x64-msvc": "1.2.7"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -4271,6 +4821,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sortablejs": {
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
@@ -4344,6 +4901,20 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -4514,6 +5085,50 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.1.tgz",
+      "integrity": "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tippy.js": {
@@ -4800,6 +5415,474 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -4902,6 +5985,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/yaml": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
@@ -4928,10 +6028,11 @@
       "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@shopperlabs/shopper-types": "^3.0.0-beta.1"
+        "@shopperlabs/shopper-types": "^3.0.0"
       },
       "devDependencies": {
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "vitest": "^4.1.11"
       }
     },
     "packages/types": {

--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -21,6 +21,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Token expiration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may set how many minutes a customer token issued by the store
+    | authentication endpoints stays valid. A null or zero value keeps the token alive
+    | until the customer logs out or resets their password. Expired tokens
+    | answer 401 and are pruned daily.
+    |
+    */
+    'token_expiration' => env('SHOPPER_API_TOKEN_EXPIRATION', 60 * 24 * 30),
+
+    /*
+    |--------------------------------------------------------------------------
     | Resource query allowlists
     |--------------------------------------------------------------------------
     |
@@ -125,10 +138,16 @@ return [
             'sorts' => ['name', 'code'],
             'includes' => [],
         ],
+        'cart' => [
+            'includes' => ['lines', 'lines.purchasable', 'lines.purchasable.product', 'addresses', 'paymentMethod'],
+        ],
         'order' => [
             'filters' => ['status' => 'exact'],
             'sorts' => ['created_at'],
-            'includes' => ['items'],
+            'includes' => ['items', 'shippingAddress', 'billingAddress', 'paymentMethod', 'shippings', 'shippings.events', 'refund'],
+            'include_loads' => [
+                'shippings' => ['shippings.carrier'],
+            ],
         ],
         'review' => [
             'filters' => ['rating' => 'exact'],

--- a/packages/api/src/Actions/ApplyCartPromotionAction.php
+++ b/packages/api/src/Actions/ApplyCartPromotionAction.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Shopper\Api\Actions;
 
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Validation\ValidationException;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Discounts\DiscountValidator;
 use Shopper\Cart\Discounts\PromotionResolver;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Models\Discount;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final readonly class ApplyCartPromotionAction
 {
@@ -35,7 +36,7 @@ final readonly class ApplyCartPromotionAction
         $discount = Discount::query()->where('code', $code)->first();
 
         if (! $discount instanceof Discount || ! $discount->is_active) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PromotionNotApplicable, [
                 'code' => __('shopper-api::messages.promotion.not_applicable'),
             ]);
         }
@@ -53,7 +54,7 @@ final readonly class ApplyCartPromotionAction
             if (! $applies) {
                 $this->cartManager->removeCoupon($cart, $code);
 
-                throw ValidationException::withMessages([
+                throw ApiValidationException::withCode(ErrorCode::PromotionNotApplicable, [
                     'code' => __('shopper-api::messages.promotion.not_applicable'),
                 ]);
             }

--- a/packages/api/src/Actions/CompleteCartAction.php
+++ b/packages/api/src/Actions/CompleteCartAction.php
@@ -4,17 +4,19 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Actions;
 
-use Illuminate\Validation\ValidationException;
 use Shopper\Api\Support\ShippingOption;
 use Shopper\Cart\Actions\CreateOrderFromCartAction;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Exceptions\CartCompletedException;
+use Shopper\Cart\Exceptions\DiscountLimitReachedException;
 use Shopper\Cart\Exceptions\InsufficientStockException;
 use Shopper\Cart\Exceptions\PriceChangedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Exceptions\CampaignBudgetExceededException;
 use Shopper\Core\Models\Contracts\Order;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 use Shopper\Payment\Actions\SettlePayment;
 use Shopper\Payment\Enum\TransactionStatus;
 use Shopper\Payment\Enum\TransactionType;
@@ -50,13 +52,13 @@ final readonly class CompleteCartAction
         $cart->load(['zone.currency', 'zone.carriers', 'lines.purchasable', 'addresses.country', 'customer']);
 
         if ($cart->lines->isEmpty()) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::CartEmpty, [
                 'cart' => __('shopper-api::messages.cart.empty'),
             ]);
         }
 
         if (! $cart->payment_method_id) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PaymentMethodRequired, [
                 'payment_method' => __('shopper-api::messages.payment.method_required'),
             ]);
         }
@@ -77,11 +79,19 @@ final readonly class CompleteCartAction
 
             return $order;
         } catch (CampaignBudgetExceededException) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PromotionBudgetReached, [
                 'promotion' => __('shopper-cart::messages.discount.campaign_budget_reached'),
             ]);
-        } catch (InsufficientStockException|PriceChangedException $exception) {
-            throw ValidationException::withMessages([
+        } catch (DiscountLimitReachedException $exception) {
+            throw ApiValidationException::withCode(ErrorCode::PromotionLimitReached, [
+                'promotion' => $exception->getMessage(),
+            ]);
+        } catch (InsufficientStockException $exception) {
+            throw ApiValidationException::withCode(ErrorCode::StockInsufficient, [
+                'cart' => $exception->getMessage(),
+            ]);
+        } catch (PriceChangedException $exception) {
+            throw ApiValidationException::withCode(ErrorCode::PriceChanged, [
                 'cart' => $exception->getMessage(),
             ]);
         }
@@ -134,7 +144,7 @@ final readonly class CompleteCartAction
         $email = $cart->customer?->getAttribute('email');
 
         if (! is_string($email)) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::EmailRequired, [
                 'email' => __('shopper-api::messages.cart.email_required'),
             ]);
         }
@@ -155,7 +165,7 @@ final readonly class CompleteCartAction
         }
 
         if (! $cart->shipping_option_id) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::ShippingMethodRequired, [
                 'shipping_method' => __('shopper-api::messages.shipping.method_required'),
             ]);
         }
@@ -168,7 +178,7 @@ final readonly class CompleteCartAction
         );
 
         if (! $option) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::ShippingOptionUnavailable, [
                 'shipping_method' => __('shopper-api::messages.shipping.option_gone'),
             ]);
         }
@@ -177,7 +187,7 @@ final readonly class CompleteCartAction
         $frozen = $cart->shipping_amount;
 
         if ($frozen !== null && $quoted > $frozen) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::ShippingPriceChanged, [
                 'shipping_method' => __('shopper-api::messages.shipping.price_changed'),
             ]);
         }
@@ -206,7 +216,7 @@ final readonly class CompleteCartAction
             $session['amount'] !== $total
             || (isset($session['currency']) && $session['currency'] !== $cart->currency_code)
         ) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PaymentSessionMismatch, [
                 'payment_session' => __('shopper-api::messages.payment.session_mismatch'),
             ]);
         }

--- a/packages/api/src/Actions/CreateCartPaymentSessionAction.php
+++ b/packages/api/src/Actions/CreateCartPaymentSessionAction.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Actions;
 
-use Illuminate\Validation\ValidationException;
 use Shopper\Api\Support\PaymentSession;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Models\Cart;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 use Shopper\Payment\Contracts\PaymentDriver;
 use Shopper\Payment\Exceptions\PaymentException;
 use Shopper\Payment\PaymentManager;
@@ -25,7 +26,7 @@ final readonly class CreateCartPaymentSessionAction
         $method = $cart->paymentMethod;
 
         if (! $method) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PaymentMethodRequired, [
                 'payment_method' => __('shopper-api::messages.payment.method_required_for_session'),
             ]);
         }
@@ -34,7 +35,7 @@ final readonly class CreateCartPaymentSessionAction
         $driver = $this->paymentManager->driver($driverCode);
 
         if (! $driver->isConfigured()) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PaymentMethodNotConfigured, [
                 'payment_method' => __('shopper-api::messages.payment.method_not_configured', ['method' => $method->title]),
             ]);
         }
@@ -42,7 +43,7 @@ final readonly class CreateCartPaymentSessionAction
         $amount = $this->cartManager->calculate($cart)->total;
 
         if ($amount <= 0) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::CartNothingToCollect, [
                 'cart' => __('shopper-api::messages.cart.nothing_to_collect'),
             ]);
         }

--- a/packages/api/src/Actions/ResolvePurchasableAction.php
+++ b/packages/api/src/Actions/ResolvePurchasableAction.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Shopper\Api\Actions;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Validation\ValidationException;
 use Shopper\Core\Contracts\Priceable;
 use Shopper\Core\Enum\ProductType;
 use Shopper\Core\Models\Contracts\Product;
 use Shopper\Core\Models\Contracts\ProductVariant;
 use Shopper\Core\Models\Price;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final class ResolvePurchasableAction
 {
@@ -21,19 +22,19 @@ final class ResolvePurchasableAction
             : $this->findProduct($publicId);
 
         if (! $purchasable instanceof Priceable) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PurchasableUnavailable, [
                 'purchasable_id' => __('shopper-api::messages.purchasable.not_available'),
             ]);
         }
 
         if ($purchasable instanceof Product && $purchasable->canUseVariants()) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::VariantRequired, [
                 'purchasable_id' => __('shopper-api::messages.purchasable.sold_through_variants'),
             ]);
         }
 
         if (! $purchasable->getPrice($currencyCode) instanceof Price) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PriceMissing, [
                 'purchasable_id' => __('shopper-api::messages.purchasable.missing_price', ['currency' => $currencyCode]),
             ]);
         }

--- a/packages/api/src/Actions/SetCartShippingMethodAction.php
+++ b/packages/api/src/Actions/SetCartShippingMethodAction.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Actions;
 
-use Illuminate\Validation\ValidationException;
 use Shopper\Api\Support\ShippingOption;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Models\Cart;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final readonly class SetCartShippingMethodAction
 {
@@ -33,7 +34,7 @@ final readonly class SetCartShippingMethodAction
         );
 
         if (! $option) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::ShippingOptionUnavailable, [
                 'option_id' => __('shopper-api::messages.shipping.option_not_available'),
             ]);
         }

--- a/packages/api/src/Actions/TransferCartAction.php
+++ b/packages/api/src/Actions/TransferCartAction.php
@@ -6,6 +6,8 @@ namespace Shopper\Api\Actions;
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Shopper\Cart\CartManager;
+use Shopper\Cart\Exceptions\CartCompletedException;
+use Shopper\Cart\Exceptions\MissingPriceException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
 
@@ -19,16 +21,24 @@ final readonly class TransferCartAction
     /**
      * Attach a guest cart to a customer, folding it into the cart the
      * customer already owns when one exists so nothing they saved earlier is
-     * lost. Transferring a cart the customer already owns is a no-op, so a
-     * retried login never fails; a cart owned by another customer is refused.
-     * Once the cart belongs to the customer, an applied coupon is
+     * lost. A guest line without a price in the customer's currency keeps
+     * the guest cart whole: it is claimed as is instead of merged, so nothing
+     * the customer picked disappears at sign in. Transferring a cart the
+     * customer already owns is a no-op, so a retried login never fails; a
+     * cart owned by another customer is refused. Once the cart belongs to
+     * the customer, an applied coupon is
      * re-validated against their redemption history and dropped if a
      * per-customer limit now rejects it.
      *
      * @throws AuthorizationException
+     * @throws CartCompletedException
      */
     public function execute(Cart $cart, int $customerId): Cart
     {
+        if ($cart->isCompleted()) {
+            throw new CartCompletedException;
+        }
+
         if ($cart->customer_id === $customerId) {
             return $cart;
         }
@@ -41,11 +51,15 @@ final readonly class TransferCartAction
         $existing = resolve(CartContract::class)::query()
             ->where('customer_id', $customerId)
             ->whereNull('completed_at')
-            ->latest()
+            ->latest('id')
             ->first();
 
         if ($existing) {
-            $cart = $this->cartManager->merge($cart, $existing);
+            try {
+                $cart = $this->cartManager->merge($cart, $existing);
+            } catch (MissingPriceException) {
+                $cart->update(['customer_id' => $customerId]);
+            }
         } else {
             $cart->update(['customer_id' => $customerId]);
         }

--- a/packages/api/src/Actions/UpdateCartAction.php
+++ b/packages/api/src/Actions/UpdateCartAction.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Actions;
 
-use Illuminate\Validation\ValidationException;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Contracts\Priceable;
 use Shopper\Core\Models\Price;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final readonly class UpdateCartAction
 {
@@ -60,7 +61,7 @@ final readonly class UpdateCartAction
             $purchasable = $line->purchasable;
 
             if (! $purchasable instanceof Priceable || ! $purchasable->getPrice($currencyCode) instanceof Price) {
-                throw ValidationException::withMessages([
+                throw ApiValidationException::withCode(ErrorCode::PriceMissing, [
                     'currency_code' => __('shopper-api::messages.purchasable.missing_price', ['currency' => $currencyCode]),
                 ]);
             }

--- a/packages/api/src/ApiServiceProvider.php
+++ b/packages/api/src/ApiServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Shopper\Api;
 
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Foundation\CachesConfiguration;
 use Illuminate\Support\Facades\Cache;
 use Shopper\Core\Models\Currency;
 use Spatie\LaravelPackageTools\Package;
@@ -23,7 +25,7 @@ final class ApiServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/api.php', 'shopper.api');
+        $this->mergeApiConfig();
 
         $this->app->singleton(Support\ResourceManifest::class);
     }
@@ -36,6 +38,44 @@ final class ApiServiceProvider extends PackageServiceProvider
         );
 
         $this->registerCurrencyCacheInvalidation();
+        $this->scheduleTokenPruning();
+    }
+
+    /**
+     * Laravel merges a published config file on its top level only, which
+     * would hide every resource or key added to the resources registry after
+     * the file was published. The registry is merged one level deeper, a
+     * published resource keeping authority over the keys it declares.
+     */
+    private function mergeApiConfig(): void
+    {
+        if ($this->app instanceof CachesConfiguration && $this->app->configurationIsCached()) {
+            return;
+        }
+
+        /** @var array{resources: array<string, mixed>} $defaults */
+        $defaults = require __DIR__.'/../config/api.php';
+
+        /** @var array<string, mixed> $published */
+        $published = (array) config('shopper.api', []);
+
+        /** @var array<string, mixed> $resources */
+        $resources = (array) ($published['resources'] ?? []);
+
+        foreach ($defaults['resources'] as $resource => $default) {
+            $resources[$resource] = is_array($default)
+                ? array_merge($default, (array) ($resources[$resource] ?? []))
+                : $resources[$resource] ?? $default;
+        }
+
+        config(['shopper.api' => array_merge($defaults, $published, ['resources' => $resources])]);
+    }
+
+    private function scheduleTokenPruning(): void
+    {
+        $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
+            $schedule->command('sanctum:prune-expired', ['--hours' => 24])->daily();
+        });
     }
 
     private function registerCurrencyCacheInvalidation(): void

--- a/packages/api/src/Concerns/BuildsApiQueries.php
+++ b/packages/api/src/Concerns/BuildsApiQueries.php
@@ -11,7 +11,8 @@ use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Illuminate\Validation\ValidationException;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedInclude;
 use Spatie\QueryBuilder\AllowedSort;
@@ -68,7 +69,7 @@ trait BuildsApiQueries
         $loads = [];
 
         foreach (QueryBuilderRequest::fromRequest(request())->includes() as $include) {
-            $loads = array_merge($loads, $map[$include] ?? []);
+            $loads = array_merge($loads, $map[$include] ?? $map[explode('.', $include, 2)[0]] ?? []);
         }
 
         return array_values(array_unique($loads));
@@ -204,7 +205,7 @@ trait BuildsApiQueries
                     ->sum(fn (mixed $value): int => mb_substr_count((string) $value, ',') + 1);
 
                 if ($breadth > self::MAX_FILTER_VALUES) {
-                    throw ValidationException::withMessages([
+                    throw ApiValidationException::withCode(ErrorCode::FilterTooWide, [
                         'filter.'.$filter => __('shopper-api::messages.catalog.filter_too_wide', ['max' => self::MAX_FILTER_VALUES]),
                     ]);
                 }

--- a/packages/api/src/Concerns/ResolvesCurrency.php
+++ b/packages/api/src/Concerns/ResolvesCurrency.php
@@ -6,8 +6,9 @@ namespace Shopper\Api\Concerns;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Validation\ValidationException;
 use Shopper\Core\Models\Currency;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 trait ResolvesCurrency
 {
@@ -40,7 +41,7 @@ trait ResolvesCurrency
             $currency = Currency::query()->where('code', mb_strtoupper($code))->first();
 
             if ($currency === null) {
-                throw ValidationException::withMessages([
+                throw ApiValidationException::withCode(ErrorCode::CurrencyUnknown, [
                     'filter.currency' => __('shopper-api::messages.catalog.unknown_currency', ['code' => $code]),
                 ]);
             }

--- a/packages/api/src/Concerns/RespondsWithCart.php
+++ b/packages/api/src/Concerns/RespondsWithCart.php
@@ -6,14 +6,23 @@ namespace Shopper\Api\Concerns;
 
 use Closure;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
+use Illuminate\Support\Collection;
 use Shopper\Api\Http\Resources\CartResource;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Exceptions\InsufficientStockException;
+use Shopper\Cart\Exceptions\MissingPriceException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
+use Shopper\Core\Models\Contracts\Product as ProductContract;
+use Shopper\Core\Models\Contracts\ProductVariant as ProductVariantContract;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiException;
+use Shopper\Http\Exceptions\ApiValidationException;
+use Spatie\QueryBuilder\Exceptions\InvalidIncludeQuery;
+use Spatie\QueryBuilder\QueryBuilderRequest;
 use Symfony\Component\HttpFoundation\Response;
 
 trait RespondsWithCart
@@ -58,26 +67,92 @@ trait RespondsWithCart
      */
     protected function cartResource(Cart $cart): CartResource
     {
+        $includes = $this->cartIncludes();
+
         $context = resolve(CartManager::class)->totals($cart);
 
-        $cart->load(['lines.purchasable', 'lines.adjustments', 'lines.taxLines', 'addresses.country', 'promotions', 'paymentMethod']);
+        $cart->load([
+            'lines.purchasable' => fn (MorphTo $purchasable) => $purchasable->morphWith($this->purchasableLoads($includes)),
+            'lines.adjustments',
+            'lines.taxLines',
+            'addresses.country',
+            'promotions',
+            'paymentMethod',
+        ]);
 
         return CartResource::make($cart)->withTotals($context);
     }
 
     /**
      * Domain failures from the cart manager become HTTP semantics: a stock
-     * shortage is a validation error on the quantity, touching a completed
-     * cart is a conflict.
+     * shortage is a validation error on the quantity, a purchasable without
+     * a price in the cart currency a validation error on the cart, touching
+     * a completed cart a conflict.
      */
     protected function mutateCart(Closure $operation): mixed
     {
         try {
             return $operation();
         } catch (InsufficientStockException $exception) {
-            throw ValidationException::withMessages(['quantity' => $exception->getMessage()]);
+            throw ApiValidationException::withCode(ErrorCode::StockInsufficient, ['quantity' => $exception->getMessage()]);
+        } catch (MissingPriceException $exception) {
+            throw ApiValidationException::withCode(ErrorCode::PriceMissing, ['cart' => $exception->getMessage()]);
         } catch (CartCompletedException $exception) {
-            abort(Response::HTTP_CONFLICT, $exception->getMessage());
+            throw new ApiException(Response::HTTP_CONFLICT, ErrorCode::CartCompleted, $exception->getMessage());
         }
+    }
+
+    /**
+     * The include paths requested on the current request, checked against the
+     * cart allowlist: a cart is served from an already loaded model, so the
+     * eager loads are decided here rather than by the spatie query builder.
+     *
+     * @return Collection<int, string>
+     */
+    private function cartIncludes(): Collection
+    {
+        $requested = QueryBuilderRequest::fromRequest(request())->includes();
+        $allowed = new Collection((array) config('shopper.api.resources.cart.includes', []));
+        $unknown = $requested->diff($allowed);
+
+        if ($unknown->isNotEmpty()) {
+            throw InvalidIncludeQuery::includesNotAllowed($unknown, $allowed);
+        }
+
+        return $requested;
+    }
+
+    /**
+     * @param  Collection<int, string>  $includes
+     * @return array<class-string, array<int, string>>
+     */
+    private function purchasableLoads(Collection $includes): array
+    {
+        if (! $includes->contains(fn (string $include): bool => str_starts_with($include, 'lines.purchasable'))) {
+            return [];
+        }
+
+        $product = resolve(ProductContract::class);
+        $variant = resolve(ProductVariantContract::class);
+
+        $productLoads = $this->serializedLoads($product);
+        $variantLoads = $this->serializedLoads($variant);
+
+        if ($includes->contains('lines.purchasable.product')) {
+            $variantLoads = [...$variantLoads, ...array_map(fn (string $load): string => 'product.'.$load, $productLoads)];
+        }
+
+        return [
+            $product::class => $productLoads,
+            $variant::class => $variantLoads,
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function serializedLoads(object $purchasable): array
+    {
+        return method_exists($purchasable, 'getMedia') ? ['prices.currency', 'media'] : ['prices.currency'];
     }
 }

--- a/packages/api/src/Http/Controllers/Account/OrderController.php
+++ b/packages/api/src/Http/Controllers/Account/OrderController.php
@@ -42,21 +42,13 @@ final class OrderController
      */
     public function show(Request $request, string $orderId): JsonApiResource
     {
-        $order = $this->orderQuery()
+        $query = $this->orderQuery()
+            ->with($this->requestedIncludeLoads('order'))
             ->where('customer_id', $request->user()?->getAuthIdentifier())
-            ->where('public_id', $orderId)
-            ->firstOrFail();
+            ->where('public_id', $orderId);
 
-        $order->load([
-            'items',
-            'shippingAddress',
-            'billingAddress',
-            'paymentMethod',
-            'shippings.carrier',
-            'shippings.events',
-            'refund',
-        ]);
+        $this->applyPublicIncludes('order', $query);
 
-        return OrderResource::make($order);
+        return OrderResource::make($query->firstOrFail());
     }
 }

--- a/packages/api/src/Http/Controllers/Auth/AuthenticationController.php
+++ b/packages/api/src/Http/Controllers/Auth/AuthenticationController.php
@@ -5,29 +5,53 @@ declare(strict_types=1);
 namespace Shopper\Api\Http\Controllers\Auth;
 
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\NewAccessToken;
 use Laravel\Sanctum\PersonalAccessToken;
 use RuntimeException;
 use Shopper\Api\Actions\RegisterCustomerAction;
+use Shopper\Api\Actions\TransferCartAction;
 use Shopper\Api\Http\Requests\Auth\LoginRequest;
 use Shopper\Api\Http\Requests\Auth\RegisterRequest;
 use Shopper\Api\Http\Resources\CustomerResource;
+use Shopper\Cart\Models\Cart;
+use Shopper\Cart\Models\Contracts\Cart as CartContract;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 final class AuthenticationController
 {
+    public function __construct(
+        private readonly DatabaseManager $database,
+        private readonly TransferCartAction $transferCart,
+    ) {}
+
+    /**
+     * Create a customer account and open a session.
+     *
+     * An optional `cart_id` attaches the guest cart to the new account.
+     * `meta.cart_id` is the customer's open cart after the call, the guest
+     * cart folded into it when one was sent, null when they have none. The
+     * cart never makes the registration fail: an unknown, completed or
+     * foreign cart is ignored.
+     */
     public function register(RegisterRequest $request, RegisterCustomerAction $action): JsonResponse
     {
         $customer = $action->execute($request->validated());
 
         /** @var JsonResponse $response */
         $response = CustomerResource::make($customer)
-            ->additional(['meta' => ['token' => $this->issueToken($customer)]])
+            ->additional(['meta' => [
+                'token' => $this->issueToken($customer),
+                'cart_id' => $this->attachCart($request, $customer),
+            ]])
             ->toResponse($request);
 
         return $response->setStatusCode(Response::HTTP_CREATED);
@@ -42,12 +66,15 @@ final class AuthenticationController
         $customer = $model::query()->where('email', $request->string('email')->toString())->first();
 
         if ($customer === null || ! Hash::check($request->string('password')->toString(), $customer->getAuthPassword())) {
-            throw ValidationException::withMessages(['email' => __('auth.failed')]);
+            throw ApiValidationException::withCode(ErrorCode::CredentialsInvalid, ['email' => __('auth.failed')]);
         }
 
         /** @var JsonResponse $response */
         $response = CustomerResource::make($customer)
-            ->additional(['meta' => ['token' => $this->issueToken($customer)]])
+            ->additional(['meta' => [
+                'token' => $this->issueToken($customer),
+                'cart_id' => $this->attachCart($request, $customer),
+            ]])
             ->toResponse($request);
 
         return $response;
@@ -64,6 +91,51 @@ final class AuthenticationController
         return response()->noContent();
     }
 
+    /**
+     * The customer's cart once the requested guest cart, if any, has been
+     * attached: the cart the transfer answered, otherwise the open cart the
+     * customer already owns. A retried call finds the guest cart already
+     * merged and still answers the surviving cart, so the client can always
+     * reconcile.
+     */
+    private function attachCart(Request $request, Model&Authenticatable $customer): ?string
+    {
+        $publicId = $request->string('cart_id')->toString();
+
+        if ($publicId !== '') {
+            try {
+                $cart = $this->database->transaction(fn (): ?Cart => $this->transferRequestedCart($publicId, $customer));
+
+                if ($cart !== null) {
+                    return $cart->public_id;
+                }
+            } catch (Throwable $exception) {
+                report($exception);
+            }
+        }
+
+        return resolve(CartContract::class)::query()
+            ->where('customer_id', $customer->getAuthIdentifier())
+            ->whereNull('completed_at')
+            ->latest('id')
+            ->value('public_id');
+    }
+
+    private function transferRequestedCart(string $publicId, Model&Authenticatable $customer): ?Cart
+    {
+        /** @var Cart|null $cart */
+        $cart = resolve(CartContract::class)::query()
+            ->wherePublicId($publicId)
+            ->whereNull('completed_at')
+            ->where(fn (Builder $query) => $query
+                ->whereNull('customer_id')
+                ->orWhere('customer_id', $customer->getAuthIdentifier()))
+            ->lockForUpdate()
+            ->first();
+
+        return $cart === null ? null : $this->transferCart->execute($cart, (int) $customer->getAuthIdentifier());
+    }
+
     private function issueToken(Model&Authenticatable $customer): string
     {
         if (! method_exists($customer, 'createToken')) {
@@ -73,8 +145,11 @@ final class AuthenticationController
             ));
         }
 
+        $minutes = config('shopper.api.token_expiration');
+        $minutes = is_numeric($minutes) ? (int) $minutes : null;
+
         /** @var NewAccessToken $token */
-        $token = $customer->createToken('store', ['store']);
+        $token = $customer->createToken('store', ['store'], $minutes !== null && $minutes > 0 ? now()->addMinutes($minutes) : null);
 
         return $token->plainTextToken;
     }

--- a/packages/api/src/Http/Controllers/Auth/PasswordResetController.php
+++ b/packages/api/src/Http/Controllers/Auth/PasswordResetController.php
@@ -9,10 +9,11 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Validation\ValidationException;
 use Laravel\Sanctum\PersonalAccessToken;
 use Shopper\Api\Http\Requests\Auth\ForgotPasswordRequest;
 use Shopper\Api\Http\Requests\Auth\ResetPasswordRequest;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 use Symfony\Component\HttpFoundation\Response;
 
 final class PasswordResetController
@@ -45,7 +46,7 @@ final class PasswordResetController
         );
 
         if ($status !== Password::PASSWORD_RESET) {
-            throw ValidationException::withMessages(['email' => __($status)]);
+            throw ApiValidationException::withCode(ErrorCode::ResetTokenInvalid, ['email' => __(Password::INVALID_TOKEN)]);
         }
 
         return response()->noContent();

--- a/packages/api/src/Http/Controllers/Cart/CartPaymentMethodController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartPaymentMethodController.php
@@ -6,7 +6,6 @@ namespace Shopper\Api\Http\Controllers\Cart;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Validation\ValidationException;
 use Shopper\Api\Concerns\RespondsWithCart;
 use Shopper\Api\Http\Requests\Cart\SetPaymentMethodRequest;
 use Shopper\Api\Http\Resources\JsonApiResource;
@@ -15,6 +14,8 @@ use Shopper\Api\Http\Resources\PaymentMethodResource;
 use Shopper\Cart\CartManager;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Models\PaymentMethod;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 use Shopper\Payment\PaymentManager;
 use Shopper\Payment\Services\PaymentProcessingService;
 
@@ -57,7 +58,7 @@ final class CartPaymentMethodController
         );
 
         if (! $method) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::PaymentMethodUnavailable, [
                 'payment_method_id' => __('shopper-api::messages.payment.method_not_available'),
             ]);
         }

--- a/packages/api/src/Http/Controllers/Cart/CartTransferController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartTransferController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use Shopper\Api\Actions\TransferCartAction;
 use Shopper\Api\Concerns\RespondsWithCart;
 use Shopper\Api\Http\Resources\JsonApiResource;
+use Shopper\Cart\Models\Cart;
 
 final class CartTransferController
 {
@@ -28,10 +29,10 @@ final class CartTransferController
      */
     public function __invoke(Request $request, string $cartId): JsonApiResource
     {
-        $cart = $this->action->execute(
+        $cart = $this->mutateCart(fn (): Cart => $this->action->execute(
             cart: $this->findCartOrFail($cartId),
             customerId: (int) $request->user()->getAuthIdentifier(),
-        );
+        ));
 
         return $this->cartResource($cart->refresh());
     }

--- a/packages/api/src/Http/Controllers/Catalog/ProductController.php
+++ b/packages/api/src/Http/Controllers/Catalog/ProductController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Controllers\Catalog;
 
-use Illuminate\Validation\ValidationException;
 use Shopper\Api\Concerns\BuildsApiQueries;
 use Shopper\Api\Concerns\HandlesPriceQueries;
 use Shopper\Api\Concerns\LoadsPriceRange;
@@ -15,6 +14,8 @@ use Shopper\Api\Http\Resources\JsonApiResource;
 use Shopper\Api\Http\Resources\JsonApiResourceCollection;
 use Shopper\Api\Http\Resources\ProductResource;
 use Shopper\Core\Models\Contracts\Product;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final class ProductController
 {
@@ -30,7 +31,7 @@ final class ProductController
         $currency = $this->resolvedCurrency();
 
         if ($currency === null && $this->wantsPriceQuery()) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::CurrencyRequired, [
                 $this->wantsPriceSort() ? 'sort' : 'filter.price_min' => __('shopper-api::messages.catalog.no_currency'),
             ]);
         }

--- a/packages/api/src/Http/Controllers/Order/OrderController.php
+++ b/packages/api/src/Http/Controllers/Order/OrderController.php
@@ -6,11 +6,12 @@ namespace Shopper\Api\Http\Controllers\Order;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
-use Illuminate\Validation\ValidationException;
 use Shopper\Api\Concerns\RespondsWithOrder;
 use Shopper\Api\Http\Resources\JsonApiResource;
 use Shopper\Api\Http\Resources\OrderResource;
 use Shopper\Core\Models\Order;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final class OrderController
 {
@@ -55,7 +56,7 @@ final class OrderController
         $forbidden = array_diff($requested, self::ALLOWED_INCLUDES);
 
         if ($forbidden !== []) {
-            throw ValidationException::withMessages([
+            throw ApiValidationException::withCode(ErrorCode::IncludeNotAllowed, [
                 'include' => __('shopper-api::messages.order.restricted_includes'),
             ]);
         }

--- a/packages/api/src/Http/Requests/Account/UpdateAvatarRequest.php
+++ b/packages/api/src/Http/Requests/Account/UpdateAvatarRequest.php
@@ -7,7 +7,8 @@ namespace Shopper\Api\Http\Requests\Account;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Validation\Rules\File;
-use Illuminate\Validation\ValidationException;
+use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiValidationException;
 
 final class UpdateAvatarRequest extends FormRequest
 {
@@ -31,7 +32,7 @@ final class UpdateAvatarRequest extends FormRequest
         $file = $this->file('avatar');
 
         if (! $file instanceof UploadedFile) {
-            throw ValidationException::withMessages(['avatar' => __('validation.image', ['attribute' => 'avatar'])]);
+            throw ApiValidationException::withCode(ErrorCode::AvatarInvalid, ['avatar' => __('validation.image', ['attribute' => 'avatar'])]);
         }
 
         return $file;

--- a/packages/api/src/Http/Requests/Auth/LoginRequest.php
+++ b/packages/api/src/Http/Requests/Auth/LoginRequest.php
@@ -21,6 +21,7 @@ final class LoginRequest extends FormRequest
         return [
             'email' => ['required', 'email'],
             'password' => ['required', 'string'],
+            'cart_id' => ['nullable', 'string', 'max:26'],
         ];
     }
 }

--- a/packages/api/src/Http/Requests/Auth/RegisterRequest.php
+++ b/packages/api/src/Http/Requests/Auth/RegisterRequest.php
@@ -30,6 +30,7 @@ final class RegisterRequest extends FormRequest
             'email' => ['required', 'email', 'max:255', Rule::unique((new $model)->getTable(), 'email')],
             'password' => ['required', 'string', Password::defaults()],
             'opt_in' => ['nullable', 'boolean'],
+            'cart_id' => ['nullable', 'string', 'max:26'],
         ];
     }
 }

--- a/packages/cart/resources/lang/en/exceptions.php
+++ b/packages/cart/resources/lang/en/exceptions.php
@@ -8,6 +8,7 @@ return [
     'cart_not_found' => 'Cart not found.',
     'insufficient_stock' => 'Insufficient stock for this item.',
     'price_changed' => 'The price of an item in your cart has changed. Please review your cart before checking out.',
+    'missing_price' => 'This item has no price in :currency.',
     'quantity_minimum' => 'Quantity must be at least 1.',
     'discount_not_found' => 'Discount code not found.',
 

--- a/packages/cart/resources/lang/es/exceptions.php
+++ b/packages/cart/resources/lang/es/exceptions.php
@@ -8,6 +8,7 @@ return [
     'cart_not_found' => 'Carrito no encontrado.',
     'insufficient_stock' => 'Stock insuficiente para este artículo.',
     'price_changed' => 'El precio de un artículo de tu carrito ha cambiado. Revisa tu carrito antes de finalizar la compra.',
+    'missing_price' => 'Este artículo no tiene precio en :currency.',
     'quantity_minimum' => 'La cantidad debe ser al menos 1.',
     'discount_not_found' => 'Código de descuento no encontrado.',
 

--- a/packages/cart/resources/lang/fr/exceptions.php
+++ b/packages/cart/resources/lang/fr/exceptions.php
@@ -8,6 +8,7 @@ return [
     'cart_not_found' => 'Panier introuvable.',
     'insufficient_stock' => 'Stock insuffisant pour cet article.',
     'price_changed' => 'Le prix d\'un article de votre panier a changé. Veuillez vérifier votre panier avant de commander.',
+    'missing_price' => 'Cet article n\'a pas de prix en :currency.',
     'quantity_minimum' => 'La quantité doit être d\'au moins 1.',
     'discount_not_found' => 'Code de réduction introuvable.',
 

--- a/packages/cart/resources/lang/sv/exceptions.php
+++ b/packages/cart/resources/lang/sv/exceptions.php
@@ -8,6 +8,7 @@ return [
     'cart_not_found' => 'Varukorgen hittades inte.',
     'insufficient_stock' => 'Otillräckligt lager för denna artikel.',
     'price_changed' => 'Priset på en artikel i varukorgen har ändrats. Vänligen granska varukorgen före kassan.',
+    'missing_price' => 'Den här artikeln har inget pris i :currency.',
     'quantity_minimum' => 'Antalet måste vara minst 1.',
     'discount_not_found' => 'Rabattkoden hittades inte.',
 

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -13,6 +13,7 @@ use Shopper\Cart\Events\CouponRemoved;
 use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Exceptions\InsufficientStockException;
 use Shopper\Cart\Exceptions\InvalidDiscountException;
+use Shopper\Cart\Exceptions\MissingPriceException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartLine;
 use Shopper\Cart\Models\CartLineAdjustment;
@@ -72,11 +73,15 @@ final readonly class CartManager
                 zoneId: $cart->zone_id,
             ));
 
+            if ($price === null) {
+                throw new MissingPriceException($purchasable, $cart->currency_code);
+            }
+
             return $cart->lines()->create([
                 'purchasable_type' => $purchasable->getMorphClass(),
                 'purchasable_id' => $purchasable->getKey(),
                 'quantity' => $quantity,
-                'unit_price_amount' => $price->amount ?? 0,
+                'unit_price_amount' => $price->amount,
                 'metadata' => $metadata,
             ]);
         });
@@ -262,7 +267,11 @@ final readonly class CartManager
                     ))
                     : null;
 
-                $line->update(['unit_price_amount' => $price->amount ?? 0]);
+                if ($price === null) {
+                    throw new MissingPriceException($purchasable, $currencyCode);
+                }
+
+                $line->update(['unit_price_amount' => $price->amount]);
             }
 
             $cart->update([
@@ -281,25 +290,42 @@ final readonly class CartManager
      * purchasable are summed, other lines move over re-priced in the target
      * currency, applied code promotions carry over without duplicating, and
      * the emptied source cart is deleted. Stock is not guarded here: the
-     * checkout reservation remains the gate, exactly as for a stale cart.
+     * checkout reservation remains the gate, exactly as for a stale cart. A
+     * line without a price in the target currency refuses the merge rather
+     * than moving for free. Both carts are re-read under lock: a concurrent
+     * merge of the same source is a no-op instead of a double count, and a
+     * target completed meanwhile is refused. The target's shipping choice
+     * and payment session are dropped once its contents changed, so they
+     * are quoted again.
      *
      * @throws Throwable
      */
     public function merge(Cart $source, Cart $target): Cart
     {
-        $this->guardCompleted($source);
-        $this->guardCompleted($target);
-        $this->invalidateTotals($target);
-
         return DB::transaction(function () use ($source, $target): Cart {
-            $source->loadMissing(['lines.purchasable.prices', 'promotions']);
+            /** @var Cart|null $source */
+            $source = $source->newQuery()->lockForUpdate()->find($source->getKey());
+
+            if ($source === null) {
+                return $target;
+            }
+
+            /** @var Cart $target */
+            $target = $target->newQuery()->lockForUpdate()->findOrFail($target->getKey());
+
+            $this->guardCompleted($source);
+            $this->guardCompleted($target);
+            $this->invalidateTotals($target);
+
+            $source->loadMissing(['lines.purchasable.prices.currency', 'promotions']);
+
+            $existingLines = $target->lines()
+                ->lockForUpdate()
+                ->get()
+                ->keyBy(fn (CartLine $line): string => $line->purchasable_type.':'.$line->purchasable_id);
 
             foreach ($source->lines as $line) {
-                $existing = $target->lines()
-                    ->where('purchasable_type', $line->purchasable_type)
-                    ->where('purchasable_id', $line->purchasable_id)
-                    ->lockForUpdate()
-                    ->first();
+                $existing = $existingLines->get($line->purchasable_type.':'.$line->purchasable_id);
 
                 if ($existing) {
                     $existing->update(['quantity' => $existing->quantity + $line->quantity]);
@@ -321,11 +347,13 @@ final readonly class CartManager
                         ))
                         : null);
 
+                if ($source->currency_code !== $target->currency_code && $price === null) {
+                    throw new MissingPriceException($purchasable, $target->currency_code);
+                }
+
                 $line->update([
                     'cart_id' => $target->id,
-                    ...($source->currency_code === $target->currency_code
-                        ? []
-                        : ['unit_price_amount' => $price->amount ?? 0]),
+                    ...($price === null ? [] : ['unit_price_amount' => $price->amount]),
                 ]);
             }
 
@@ -334,6 +362,11 @@ final readonly class CartManager
                     ['discount_id' => $promotion->discount_id],
                     ['source' => $promotion->source, 'code' => $promotion->code],
                 );
+            }
+
+            if ($source->lines->isNotEmpty()) {
+                $target->update(['shipping_option_id' => null, 'shipping_amount' => null]);
+                $this->setPaymentSession($target, null);
             }
 
             $source->delete();

--- a/packages/cart/src/CartSessionManager.php
+++ b/packages/cart/src/CartSessionManager.php
@@ -6,6 +6,7 @@ namespace Shopper\Cart;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Session\SessionManager;
+use Shopper\Cart\Exceptions\MissingPriceException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\Contracts\Cart as CartContract;
 
@@ -85,11 +86,12 @@ final class CartSessionManager
             ->first();
 
         if ($existing) {
-            $merged = resolve(CartManager::class)->merge($cart, $existing);
+            try {
+                $this->use(resolve(CartManager::class)->merge($cart, $existing));
 
-            $this->use($merged);
-
-            return;
+                return;
+            } catch (MissingPriceException) {
+            }
         }
 
         $cart->update(['customer_id' => $user->getAuthIdentifier()]);

--- a/packages/cart/src/Exceptions/MissingPriceException.php
+++ b/packages/cart/src/Exceptions/MissingPriceException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Cart\Exceptions;
+
+use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
+
+final class MissingPriceException extends RuntimeException
+{
+    public function __construct(
+        public readonly ?Model $purchasable,
+        public readonly string $currencyCode,
+    ) {
+        parent::__construct(__('shopper-cart::exceptions.missing_price', ['currency' => $currencyCode]));
+    }
+}

--- a/packages/http/src/Enum/ErrorCode.php
+++ b/packages/http/src/Enum/ErrorCode.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Enum;
+
+use Symfony\Component\HttpFoundation\Response;
+
+enum ErrorCode: string
+{
+    case BadRequest = 'bad_request';
+    case Unauthenticated = 'unauthenticated';
+    case Forbidden = 'forbidden';
+    case NotFound = 'not_found';
+    case MethodNotAllowed = 'method_not_allowed';
+    case Conflict = 'conflict';
+    case Invalid = 'invalid';
+    case RateLimited = 'rate_limited';
+    case ServerError = 'server_error';
+    case HttpError = 'http_error';
+
+    case CredentialsInvalid = 'credentials_invalid';
+    case ResetTokenInvalid = 'reset_token_invalid';
+
+    case IncludeNotAllowed = 'include_not_allowed';
+    case FilterTooWide = 'filter_too_wide';
+    case CurrencyRequired = 'currency_required';
+    case CurrencyUnknown = 'currency_unknown';
+
+    case PurchasableUnavailable = 'purchasable_unavailable';
+    case VariantRequired = 'variant_required';
+    case PriceMissing = 'price_missing';
+    case PriceChanged = 'price_changed';
+    case StockInsufficient = 'stock_insufficient';
+    case CartEmpty = 'cart_empty';
+    case CartCompleted = 'cart_completed';
+    case CartNothingToCollect = 'cart_nothing_to_collect';
+    case EmailRequired = 'email_required';
+    case PromotionNotApplicable = 'promotion_not_applicable';
+    case PromotionBudgetReached = 'promotion_budget_reached';
+    case PromotionLimitReached = 'promotion_limit_reached';
+
+    case ShippingMethodRequired = 'shipping_method_required';
+    case ShippingOptionUnavailable = 'shipping_option_unavailable';
+    case ShippingPriceChanged = 'shipping_price_changed';
+
+    case PaymentMethodRequired = 'payment_method_required';
+    case PaymentMethodUnavailable = 'payment_method_unavailable';
+    case PaymentMethodNotConfigured = 'payment_method_not_configured';
+    case PaymentSessionMismatch = 'payment_session_mismatch';
+
+    case AvatarInvalid = 'avatar_invalid';
+
+    public static function fromStatus(int $status): self
+    {
+        return match (true) {
+            $status === Response::HTTP_BAD_REQUEST => self::BadRequest,
+            $status === Response::HTTP_UNAUTHORIZED => self::Unauthenticated,
+            $status === Response::HTTP_FORBIDDEN => self::Forbidden,
+            $status === Response::HTTP_NOT_FOUND => self::NotFound,
+            $status === Response::HTTP_METHOD_NOT_ALLOWED => self::MethodNotAllowed,
+            $status === Response::HTTP_CONFLICT => self::Conflict,
+            $status === Response::HTTP_TOO_MANY_REQUESTS => self::RateLimited,
+            $status >= Response::HTTP_INTERNAL_SERVER_ERROR => self::ServerError,
+            default => self::HttpError,
+        };
+    }
+}

--- a/packages/http/src/Exceptions/ApiException.php
+++ b/packages/http/src/Exceptions/ApiException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Exceptions;
+
+use Shopper\Http\Enum\ErrorCode;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ApiException extends HttpException
+{
+    public function __construct(
+        int $status,
+        public readonly ErrorCode $errorCode,
+        string $message = '',
+    ) {
+        parent::__construct($status, $message);
+    }
+}

--- a/packages/http/src/Exceptions/ApiValidationException.php
+++ b/packages/http/src/Exceptions/ApiValidationException.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Http\Exceptions;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Validation\ValidationException;
+use Shopper\Http\Enum\ErrorCode;
+
+final class ApiValidationException extends ValidationException
+{
+    public function __construct(
+        Validator $validator,
+        public readonly ErrorCode $errorCode = ErrorCode::Invalid,
+    ) {
+        parent::__construct($validator);
+    }
+
+    /**
+     * @param  array<string, string|array<int, string>>  $messages
+     */
+    public static function withCode(ErrorCode $code, array $messages): self
+    {
+        return new self(ValidationException::withMessages($messages)->validator, $code);
+    }
+}

--- a/packages/http/src/Exceptions/JsonApiErrorRenderer.php
+++ b/packages/http/src/Exceptions/JsonApiErrorRenderer.php
@@ -4,22 +4,17 @@ declare(strict_types=1);
 
 namespace Shopper\Http\Exceptions;
 
-use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use Shopper\Http\Enum\ErrorCode;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
-/**
- * Renders exceptions thrown on Shopper API routes as JSON:API error documents
- * ({ "errors": [...] }) with the application/vnd.api+json content type, so the
- * error contract matches the success contract. Returns null for non-API routes,
- * letting the default handler take over.
- */
 final class JsonApiErrorRenderer
 {
     public function render(Throwable $exception, Request $request): ?JsonResponse
@@ -34,21 +29,20 @@ final class JsonApiErrorRenderer
 
         $status = match (true) {
             $exception instanceof AuthenticationException => Response::HTTP_UNAUTHORIZED,
-            $exception instanceof AuthorizationException => Response::HTTP_FORBIDDEN,
-            $exception instanceof ModelNotFoundException => Response::HTTP_NOT_FOUND,
             $exception instanceof HttpExceptionInterface => $exception->getStatusCode(),
             default => Response::HTTP_INTERNAL_SERVER_ERROR,
         };
 
-        $detail = $exception instanceof HttpExceptionInterface && $exception->getMessage() !== ''
-            ? $exception->getMessage()
-            : $this->title($status);
-
-        return $this->response($status, [[
-            'status' => (string) $status,
-            'title' => $this->title($status),
-            'detail' => $detail,
-        ]]);
+        return $this->response(
+            $status,
+            [[
+                'status' => (string) $status,
+                'code' => $this->code($exception, $status)->value,
+                'title' => $this->title($status),
+                'detail' => $this->detail($exception, $status),
+            ]],
+            $exception instanceof HttpExceptionInterface ? $exception->getHeaders() : [],
+        );
     }
 
     private function handlesRequest(Request $request): bool
@@ -58,37 +52,82 @@ final class JsonApiErrorRenderer
         return $prefix !== '' && $request->is($prefix.'/*');
     }
 
+    private function code(Throwable $exception, int $status): ErrorCode
+    {
+        return $exception instanceof ApiException
+            ? $exception->errorCode
+            : ErrorCode::fromStatus($status);
+    }
+
+    /**
+     * The message of an HTTP exception is written for the client
+     */
+    private function detail(Throwable $exception, int $status): string
+    {
+        if ($exception instanceof AuthenticationException) {
+            return $exception->getMessage();
+        }
+
+        if (
+            $exception instanceof HttpExceptionInterface
+            && $exception->getMessage() !== ''
+            && ! $exception->getPrevious() instanceof ModelNotFoundException
+        ) {
+            return $exception->getMessage();
+        }
+
+        return $this->title($status);
+    }
+
     /**
      * @param  array<int, array<string, mixed>>  $errors
+     * @param  array<string, string>  $headers
      */
-    private function response(int $status, array $errors): JsonResponse
+    private function response(int $status, array $errors, array $headers = []): JsonResponse
     {
         return new JsonResponse(
             data: ['errors' => $errors],
             status: $status,
-            headers: ['Content-Type' => 'application/vnd.api+json'],
+            headers: [...$headers, 'Content-Type' => 'application/vnd.api+json'],
         );
     }
 
     /**
+     * One error object per message
+     *
      * @return array<int, array<string, mixed>>
      */
     private function validationErrors(ValidationException $exception): array
     {
         $errors = [];
+        $failed = $exception->validator->failed();
 
         foreach ($exception->errors() as $field => $messages) {
-            foreach ($messages as $message) {
+            $rules = array_keys($failed[$field] ?? []);
+
+            foreach (array_values($messages) as $index => $message) {
                 $errors[] = [
                     'status' => (string) $exception->status,
+                    'code' => $this->validationCode($exception, count($rules) === 1 ? $rules[0] : ($rules[$index] ?? null)),
                     'title' => $this->title($exception->status),
                     'detail' => $message,
-                    'source' => ['pointer' => '/data/attributes/'.$field],
+                    'source' => ['pointer' => '/data/attributes/'.str_replace('.', '/', $field)],
                 ];
             }
         }
 
         return $errors;
+    }
+
+    private function validationCode(ValidationException $exception, ?string $rule): string
+    {
+        if ($exception instanceof ApiValidationException) {
+            return $exception->errorCode->value;
+        }
+
+        return $rule === null
+            ? ErrorCode::Invalid->value
+            : Str::snake(class_basename($rule));
     }
 
     private function title(int $status): string

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -38,12 +38,14 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
+    "test": "vitest run",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@shopperlabs/shopper-types": "^3.0.0"
   },
   "devDependencies": {
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^4.1.11"
   }
 }

--- a/packages/sdk/src/auth.ts
+++ b/packages/sdk/src/auth.ts
@@ -9,11 +9,15 @@ export interface RegisterPayload {
   email: string
   password: string
   opt_in?: boolean
+  /** A guest cart to attach to the new account; the resulting cart id is exposed by getCartId(). */
+  cart_id?: string
 }
 
 export interface LoginPayload {
   email: string
   password: string
+  /** A guest cart to attach to the customer, folded into the cart they already own when one exists. */
+  cart_id?: string
 }
 
 export interface ResetPasswordPayload {
@@ -28,6 +32,8 @@ export interface ResetPasswordPayload {
  * as a Bearer header. logout() revokes the token server side and purges it.
  */
 export class AuthModule {
+  private cartId: string | null = null
+
   public constructor(private readonly client: HttpClient) {}
 
   public async register(payload: RegisterPayload): Promise<Customer> {
@@ -43,6 +49,7 @@ export class AuthModule {
       await this.client.send('POST', `/${this.client.storePrefix}/auth/logout`)
     } finally {
       this.client.tokens.clear()
+      this.cartId = null
     }
   }
 
@@ -59,6 +66,15 @@ export class AuthModule {
     return this.client.tokens.get()
   }
 
+  /**
+   * The id of the cart attached during the last register() or login() call,
+   * when a cart_id was sent. It may differ from the id sent: a guest cart
+   * folded into the cart the customer already owned is gone after the merge.
+   */
+  public getCartId(): string | null {
+    return this.cartId
+  }
+
   private async authenticate(endpoint: string, payload: Record<string, unknown>): Promise<Customer> {
     const document = await this.client.send('POST', `/${this.client.storePrefix}/auth/${endpoint}`, payload)
 
@@ -71,6 +87,10 @@ export class AuthModule {
     if (typeof token === 'string') {
       this.client.tokens.set(token)
     }
+
+    const cartId = document.meta?.cart_id
+
+    this.cartId = typeof cartId === 'string' ? cartId : null
 
     return flatten<Customer>(document) as Customer
   }

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -51,6 +51,13 @@ export interface ShopperConfig {
   fetch?: typeof globalThis.fetch
   /** Customer token persistence. Defaults to an in-memory store. */
   tokenStorage?: TokenStorage
+  /**
+   * Called once per 401 answered to a request that carried an Authorization
+   * header, from the token storage or from the configured headers, after the
+   * token storage has been cleared and before the error is thrown. Never
+   * called for an anonymous request nor for a 403.
+   */
+  onUnauthorized?: () => void | Promise<void>
 }
 
 /**
@@ -70,6 +77,8 @@ export class HttpClient {
 
   private readonly fetchImpl: typeof globalThis.fetch
 
+  private readonly onUnauthorized: (() => void | Promise<void>) | null
+
   private locale: string | null
 
   private channel: string | null
@@ -81,6 +90,7 @@ export class HttpClient {
     this.channel = config.channel ?? null
     this.headers = config.headers ?? {}
     this.tokens = config.tokenStorage ?? new MemoryTokenStorage()
+    this.onUnauthorized = config.onUnauthorized ?? null
     // Bind to the global so the browser fetch keeps `this === window`
     this.fetchImpl = (config.fetch ?? globalThis.fetch).bind(globalThis)
   }
@@ -124,23 +134,32 @@ export class HttpClient {
     const isForm = typeof FormData !== 'undefined' && body instanceof FormData
     const { headers: initHeaders, ...initRest } = init ?? {}
 
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.api+json',
+      ...(body !== undefined && ! isForm ? { 'Content-Type': 'application/json' } : {}),
+      ...(token !== null ? { Authorization: `Bearer ${token}` } : {}),
+      ...(this.locale !== null ? { 'Accept-Language': this.locale } : {}),
+      ...(this.channel !== null ? { 'X-Shopper-Channel': this.channel } : {}),
+      ...this.headers,
+      ...initHeaders,
+    }
+
     const response = await this.fetchImpl(url, {
       ...initRest,
       method,
-      headers: {
-        Accept: 'application/vnd.api+json',
-        ...(body !== undefined && ! isForm ? { 'Content-Type': 'application/json' } : {}),
-        ...(token !== null ? { Authorization: `Bearer ${token}` } : {}),
-        ...(this.locale !== null ? { 'Accept-Language': this.locale } : {}),
-        ...(this.channel !== null ? { 'X-Shopper-Channel': this.channel } : {}),
-        ...this.headers,
-        ...initHeaders,
-      },
+      headers,
       ...(body !== undefined ? { body: isForm ? (body as FormData) : JSON.stringify(body) } : {}),
     })
 
     if (! response.ok) {
-      throw await toApiError(response)
+      const error = await toApiError(response)
+
+      if (response.status === 401 && (headers.Authorization ?? headers.authorization) !== undefined) {
+        this.tokens.clear()
+        await this.onUnauthorized?.()
+      }
+
+      throw error
     }
 
     if (response.status === 204 || response.status === 202) {

--- a/packages/sdk/src/http.ts
+++ b/packages/sdk/src/http.ts
@@ -102,6 +102,47 @@ export class ShopperApiError extends Error {
     this.status = status
     this.errors = errors
   }
+
+  /** The code of the first error, when the API provides one. */
+  public get code(): string | undefined {
+    return this.errors[0]?.code
+  }
+
+  /** The code reported for a field, when the API provides one. */
+  public codeFor(field: string): string | undefined {
+    return this.errors.find((error) => ShopperApiError.fieldOf(error.source?.pointer) === field)?.code
+  }
+
+  /**
+   * Messages grouped by field name, read from `source.pointer`
+   * (`/data/attributes/email` becomes `email`). Errors without a pointer are
+   * left out; they stay readable through `errors`.
+   */
+  public fields(): Record<string, string[]> {
+    const fields: Record<string, string[]> = {}
+
+    for (const error of this.errors) {
+      const field = ShopperApiError.fieldOf(error.source?.pointer)
+
+      if (field === undefined || error.detail === undefined) {
+        continue
+      }
+
+      fields[field] = [...(fields[field] ?? []), error.detail]
+    }
+
+    return fields
+  }
+
+  private static fieldOf(pointer: string | undefined): string | undefined {
+    if (pointer === undefined) {
+      return undefined
+    }
+
+    const field = pointer.replace(/^\/data\/attributes\//, '').replace(/\//g, '.')
+
+    return field === '__proto__' || field === 'constructor' || field === 'prototype' ? undefined : field
+  }
 }
 
 export async function toApiError(response: Response): Promise<ShopperApiError> {

--- a/packages/sdk/src/json-api.ts
+++ b/packages/sdk/src/json-api.ts
@@ -29,6 +29,8 @@ export interface JsonApiDocument {
 
 export interface JsonApiError {
   status?: string
+  /** Stable, untranslated machine code: the failed validation rule (unique, required, ...) or a domain code (credentials_invalid, stock_insufficient, ...). */
+  code?: string
   title?: string
   detail?: string
   source?: { pointer?: string; parameter?: string }

--- a/packages/sdk/src/store/cart.ts
+++ b/packages/sdk/src/store/cart.ts
@@ -106,7 +106,9 @@ export class CartModule {
   /**
    * Attach a guest cart to the authenticated customer, used when a guest signs
    * in mid-checkout. Requires a customer token. Idempotent for a cart they
-   * already own; rejected for a cart that belongs to another customer.
+   * already own; rejected for a cart that belongs to another customer. Keep
+   * the id of the returned cart: when the customer already owned one, the
+   * guest cart is folded into it and the id sent is gone after the merge.
    */
   public async transfer(cartId: string, params?: RequestParams): Promise<Cart> {
     const document = await this.client.send('POST', `${this.path}/${cartId}/transfer`, undefined, this.params(params))

--- a/packages/sdk/tests/auth.test.ts
+++ b/packages/sdk/tests/auth.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { AuthModule } from '../src/auth'
+import { HttpClient } from '../src/client'
+import { fakeFetch, json } from './support'
+
+const customer = { id: '01CUSTOMER', type: 'customers', attributes: { email: 'jane@example.com', last_name: 'Doe' } }
+
+describe('AuthModule', () => {
+  it('captures the token and the attached cart id from the authentication meta', async () => {
+    const { fetch, calls } = fakeFetch([
+      json(201, { data: customer, meta: { token: 'secret', cart_id: '01OWNEDCART' } }),
+      json(204, {}),
+    ])
+    const client = new HttpClient({ baseUrl: 'https://shop.test', fetch })
+    const auth = new AuthModule(client)
+
+    await auth.register({ last_name: 'Doe', email: 'jane@example.com', password: 'super-secret', cart_id: '01GUESTCART' })
+
+    expect(JSON.parse(String(calls[0]?.init.body))).toMatchObject({ cart_id: '01GUESTCART' })
+    expect(auth.getToken()).toBe('secret')
+    expect(auth.getCartId()).toBe('01OWNEDCART')
+
+    await auth.logout()
+
+    expect(auth.getToken()).toBeNull()
+    expect(auth.getCartId()).toBeNull()
+  })
+
+  it('answers a null cart id when nothing was attached', async () => {
+    const { fetch } = fakeFetch([json(200, { data: customer, meta: { token: 'secret', cart_id: null } })])
+    const auth = new AuthModule(new HttpClient({ baseUrl: 'https://shop.test', fetch }))
+
+    await auth.login({ email: 'jane@example.com', password: 'super-secret' })
+
+    expect(auth.getCartId()).toBeNull()
+  })
+})

--- a/packages/sdk/tests/client.test.ts
+++ b/packages/sdk/tests/client.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { HttpClient } from '../src/client'
+import { ShopperApiError } from '../src/http'
+import { fakeFetch, json } from './support'
+
+const unauthorized = json(401, { errors: [{ status: '401', code: 'unauthenticated', title: 'Unauthorized', detail: 'Unauthenticated.' }] })
+const forbidden = json(403, { errors: [{ status: '403', code: 'forbidden', title: 'Forbidden', detail: 'Forbidden' }] })
+
+describe('HttpClient', () => {
+  it('clears the token and calls onUnauthorized once on a 401 carrying a token', async () => {
+    const onUnauthorized = vi.fn()
+    const { fetch } = fakeFetch([unauthorized])
+    const client = new HttpClient({ baseUrl: 'https://shop.test', fetch, onUnauthorized })
+
+    client.tokens.set('secret')
+
+    await expect(client.request('/store/customers/me')).rejects.toBeInstanceOf(ShopperApiError)
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+    expect(client.tokens.get()).toBeNull()
+  })
+
+  it('fires onUnauthorized when the Authorization header comes from the configured headers', async () => {
+    const onUnauthorized = vi.fn()
+    const { fetch } = fakeFetch([unauthorized])
+    const client = new HttpClient({
+      baseUrl: 'https://shop.test',
+      fetch,
+      onUnauthorized,
+      headers: { Authorization: 'Bearer static-token' },
+    })
+
+    await expect(client.request('/store/customers/me')).rejects.toBeInstanceOf(ShopperApiError)
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves an anonymous 401 and a 403 alone', async () => {
+    const onUnauthorized = vi.fn()
+    const { fetch } = fakeFetch([unauthorized, forbidden])
+    const client = new HttpClient({ baseUrl: 'https://shop.test', fetch, onUnauthorized })
+
+    await expect(client.request('/store/customers/me')).rejects.toMatchObject({ status: 401 })
+
+    client.tokens.set('secret')
+
+    await expect(client.request('/store/customers/me')).rejects.toMatchObject({ status: 403 })
+
+    expect(onUnauthorized).not.toHaveBeenCalled()
+    expect(client.tokens.get()).toBe('secret')
+  })
+})

--- a/packages/sdk/tests/errors.test.ts
+++ b/packages/sdk/tests/errors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { ShopperApiError } from '../src/http'
+
+describe('ShopperApiError', () => {
+  it('exposes the first code and groups messages by field', () => {
+    const error = new ShopperApiError(422, [
+      { status: '422', code: 'unique', detail: 'The email has already been taken.', source: { pointer: '/data/attributes/email' } },
+      { status: '422', code: 'required', detail: 'The last name field is required.', source: { pointer: '/data/attributes/last_name' } },
+      { status: '422', code: 'currency_unknown', detail: 'Unknown currency.', source: { pointer: '/data/attributes/filter/currency' } },
+      { status: '422', code: 'invalid', detail: 'No pointer here.' },
+    ])
+
+    expect(error.code).toBe('unique')
+    expect(error.fields()).toEqual({
+      email: ['The email has already been taken.'],
+      last_name: ['The last name field is required.'],
+      'filter.currency': ['Unknown currency.'],
+    })
+    expect(error.message).toBe('The email has already been taken.')
+  })
+
+  it('reports the code of a given field whatever the error order', () => {
+    const error = new ShopperApiError(422, [
+      { status: '422', code: 'min', detail: 'The password must be at least 8 characters.', source: { pointer: '/data/attributes/password' } },
+      { status: '422', code: 'unique', detail: 'The email has already been taken.', source: { pointer: '/data/attributes/email' } },
+      { status: '422', detail: 'No code here.', source: { pointer: '/data/attributes/last_name' } },
+    ])
+
+    expect(error.codeFor('email')).toBe('unique')
+    expect(error.codeFor('password')).toBe('min')
+    expect(error.codeFor('last_name')).toBeUndefined()
+    expect(error.codeFor('first_name')).toBeUndefined()
+  })
+})

--- a/packages/sdk/tests/support.ts
+++ b/packages/sdk/tests/support.ts
@@ -1,0 +1,32 @@
+import type { JsonApiDocument, JsonApiErrorDocument } from '../src/json-api'
+
+export interface Call {
+  url: string
+  init: RequestInit
+}
+
+export function fakeFetch(responses: Array<() => Response>): { fetch: typeof globalThis.fetch; calls: Call[] } {
+  const calls: Call[] = []
+  const queue = [...responses]
+
+  const fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    calls.push({ url: String(input), init: init ?? {} })
+
+    const next = queue.shift()
+
+    if (next === undefined) {
+      throw new Error('No fake response left.')
+    }
+
+    return next()
+  }) as typeof globalThis.fetch
+
+  return { fetch, calls }
+}
+
+export function json(status: number, body: JsonApiDocument | JsonApiErrorDocument | Record<string, unknown>): () => Response {
+  return () =>
+    status === 204
+      ? new Response(null, { status })
+      : new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/vnd.api+json' } })
+}

--- a/tests/Api/Feature/ApiServiceProviderTest.php
+++ b/tests/Api/Feature/ApiServiceProviderTest.php
@@ -14,3 +14,21 @@ it('merges the api config under the `shopper` namespace', function (): void {
 it('registers the api service provider', function (): void {
     expect(app()->getLoadedProviders())->toHaveKey(ApiServiceProvider::class);
 });
+
+it('keeps the package defaults for the resources and keys a published config does not declare', function (): void {
+    config()->set('shopper.api', [
+        'resources' => [
+            'order' => ['includes' => ['items']],
+            'max_age' => 60,
+        ],
+    ]);
+
+    (new ApiServiceProvider($this->app))->packageRegistered();
+
+    expect(config('shopper.api.resources.cart.includes'))->toContain('lines.purchasable.product')
+        ->and(config('shopper.api.resources.order.includes'))->toBe(['items'])
+        ->and(config('shopper.api.resources.order.include_loads'))->toBe(['shippings' => ['shippings.carrier']])
+        ->and(config('shopper.api.resources.order.filters'))->toBe(['status' => 'exact'])
+        ->and(config('shopper.api.resources.max_age'))->toBe(60)
+        ->and(config('shopper.api.pagination.per_page'))->toBe(15);
+});

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Testing\TestResponse;
 use Laravel\Sanctum\Sanctum;
 use Shopper\Cart\CartManager;
@@ -23,6 +24,7 @@ use Shopper\Core\Models\Product;
 use Shopper\Core\Models\ProductVariant;
 use Shopper\Core\Models\TaxRate;
 use Shopper\Core\Models\TaxZone;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Api\TestCase::class);
@@ -44,6 +46,7 @@ beforeEach(function (): void {
         'currency_id' => $this->currency->id,
     ]);
     $this->product->mutateStock($this->inventory->id, 50);
+    $this->product->refresh();
 });
 
 it('creates a guest cart with the default currency', function (): void {
@@ -210,16 +213,16 @@ it('rejects purchasables a storefront cannot sell', function (): void {
     $unpriced = Product::factory()->standard()->publish()->create();
 
     foreach ([
-        '01JUNKNOWNPURCHASABLEID000',
-        $draft->public_id,
-        $external->public_id,
-        $parent->public_id,
-        $unpriced->public_id,
-    ] as $publicId) {
+        '01JUNKNOWNPURCHASABLEID000' => 'purchasable_unavailable',
+        $draft->public_id => 'purchasable_unavailable',
+        $external->public_id => 'purchasable_unavailable',
+        $parent->public_id => 'variant_required',
+        $unpriced->public_id => 'price_missing',
+    ] as $publicId => $code) {
         $this->postJson("/store/carts/{$cartId}/lines", [
             'purchasable_type' => 'product',
             'purchasable_id' => $publicId,
-        ])->assertUnprocessable();
+        ])->assertUnprocessable()->assertJsonPath('errors.0.code', $code);
     }
 });
 
@@ -230,7 +233,7 @@ it('returns a validation error when stock is insufficient', function (): void {
         'purchasable_type' => 'product',
         'purchasable_id' => $this->product->public_id,
         'quantity' => 100,
-    ])->assertUnprocessable();
+    ])->assertUnprocessable()->assertJsonPath('errors.0.code', 'stock_insufficient');
 });
 
 it('updates the quantity of a line and removes it', function (): void {
@@ -263,7 +266,7 @@ it('returns a conflict when mutating a completed cart', function (): void {
     $this->postJson("/store/carts/{$cart->public_id}/lines", [
         'purchasable_type' => 'product',
         'purchasable_id' => $this->product->public_id,
-    ])->assertConflict();
+    ])->assertConflict()->assertJsonPath('errors.0.code', 'cart_completed');
 });
 
 it('exposes the cart addresses as an include', function (): void {
@@ -418,6 +421,7 @@ it('rejects a currency that is enabled but not configured for the shop', functio
 
     $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'EUR'])
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'exists')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/currency_code');
 
     expect($cart->refresh()->currency_code)->toBe('USD');
@@ -437,6 +441,7 @@ it('rejects a currency change when a line has no price in it', function (): void
 
     $this->patchJson("/store/carts/{$cart->public_id}", ['currency_code' => 'EUR'])
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'price_missing')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/currency_code');
 
     expect($cart->refresh()->currency_code)->toBe('USD');
@@ -591,6 +596,103 @@ it('refuses to transfer a cart owned by another customer', function (): void {
     expect($cart->refresh()->customer_id)->toBe($owner->id);
 });
 
+it('refuses to transfer a completed guest cart', function (): void {
+    $cart = Cart::factory()->create(['currency_code' => 'USD', 'completed_at' => now()]);
+
+    Sanctum::actingAs(User::factory()->create(), ['store']);
+
+    $this->postJson("/store/carts/{$cart->public_id}/transfer")
+        ->assertConflict()
+        ->assertJsonPath('errors.0.code', 'cart_completed');
+});
+
+it('attaches the guest cart to the new account at registration', function (): void {
+    $cart = Cart::factory()->create(['currency_code' => 'USD']);
+
+    $response = $this->postJson('/store/auth/register', [
+        'last_name' => 'Doe',
+        'email' => 'jane@example.com',
+        'password' => 'super-secret-password',
+        'cart_id' => $cart->public_id,
+    ])->assertCreated()->assertJsonPath('meta.cart_id', $cart->public_id);
+
+    expect($cart->refresh()->customer_id)->toBe(User::query()->where('email', 'jane@example.com')->firstOrFail()->id);
+
+    $this->getJson("/store/carts/{$cart->public_id}", ['Authorization' => 'Bearer '.$response->json('meta.token')])->assertOk();
+});
+
+it('folds the guest cart into the cart the customer already owns at login', function (): void {
+    $customer = User::factory()->create(['email' => 'john@example.com', 'password' => Hash::make('correct-password')]);
+
+    $guestCart = Cart::factory()->create(['currency_code' => 'USD']);
+    $ownedCart = Cart::factory()->create(['currency_code' => 'USD', 'customer_id' => $customer->id]);
+
+    $cartManager = resolve(CartManager::class);
+    $cartManager->add($guestCart, $this->product, quantity: 2);
+    $cartManager->add($ownedCart, $this->product, quantity: 1);
+
+    $login = ['email' => 'john@example.com', 'password' => 'correct-password', 'cart_id' => $guestCart->public_id];
+
+    $this->postJson('/store/auth/login', $login)->assertOk()->assertJsonPath('meta.cart_id', $ownedCart->public_id);
+
+    expect($ownedCart->lines()->first()->quantity)->toBe(3)
+        ->and(Cart::query()->find($guestCart->id))->toBeNull();
+
+    $this->postJson('/store/auth/login', $login)->assertOk()->assertJsonPath('meta.cart_id', $ownedCart->public_id);
+
+    expect($ownedCart->lines()->first()->quantity)->toBe(3);
+});
+
+it('claims a guest cart whole when a line has no price in the customer currency', function (): void {
+    $customer = User::factory()->create(['email' => 'john@example.com', 'password' => Hash::make('correct-password')]);
+
+    $guestCart = Cart::factory()->create(['currency_code' => 'USD']);
+    $ownedCart = Cart::factory()->create(['currency_code' => 'EUR', 'customer_id' => $customer->id]);
+
+    resolve(CartManager::class)->add($guestCart, $this->product, quantity: 2);
+
+    $this->postJson('/store/auth/login', [
+        'email' => 'john@example.com',
+        'password' => 'correct-password',
+        'cart_id' => $guestCart->public_id,
+    ])->assertOk()->assertJsonPath('meta.cart_id', $guestCart->public_id);
+
+    expect($guestCart->refresh()->customer_id)->toBe($customer->id)
+        ->and($guestCart->currency_code)->toBe('USD')
+        ->and($guestCart->lines()->first()->unit_price_amount)->toBe(2500)
+        ->and($ownedCart->lines()->count())->toBe(0);
+
+    $otherGuestCart = Cart::factory()->create(['currency_code' => 'USD']);
+    resolve(CartManager::class)->add($otherGuestCart, $this->product, quantity: 1);
+
+    Sanctum::actingAs($customer, ['store']);
+
+    $this->postJson("/store/carts/{$otherGuestCart->public_id}/transfer")
+        ->assertOk()
+        ->assertJsonPath('data.id', $otherGuestCart->public_id);
+
+    expect($otherGuestCart->refresh()->customer_id)->toBe($customer->id);
+});
+
+it('ignores an unknown, completed or foreign cart at login', function (): void {
+    $owner = User::factory()->create();
+    User::factory()->create(['email' => 'john@example.com', 'password' => Hash::make('correct-password')]);
+
+    $completed = Cart::factory()->create(['currency_code' => 'USD', 'completed_at' => now()]);
+    $foreign = Cart::factory()->create(['currency_code' => 'USD', 'customer_id' => $owner->id]);
+
+    foreach (['01JUNKNOWNCARTIDENTIFIER00', $completed->public_id, $foreign->public_id] as $cartId) {
+        $this->postJson('/store/auth/login', [
+            'email' => 'john@example.com',
+            'password' => 'correct-password',
+            'cart_id' => $cartId,
+        ])->assertOk()->assertJsonPath('meta.cart_id', null);
+    }
+
+    expect($foreign->refresh()->customer_id)->toBe($owner->id)
+        ->and($completed->refresh()->customer_id)->toBeNull();
+});
+
 it('requires authentication to transfer a cart', function (): void {
     $cart = Cart::factory()->create(['currency_code' => 'USD']);
 
@@ -637,14 +739,31 @@ it('serializes a product line and a variant line of the same cart', function ():
     expect($types)->toBe(['cart-lines', 'products', 'variants']);
 });
 
-it('never loads a relation of a purchasable through a nested include', function (): void {
+it('rejects an include outside the cart allowlist', function (): void {
     $hidden = Category::factory()->create(['name' => 'Hidden', 'slug' => 'hidden', 'is_enabled' => false]);
     $this->product->categories()->attach($hidden);
 
     $cartId = $this->postJson('/store/carts')->json('data.id');
     $this->postJson("/store/carts/{$cartId}/lines", ['purchasable_type' => 'product', 'purchasable_id' => $this->product->public_id])->assertOk();
 
-    $included = collect($this->getJson("/store/carts/{$cartId}?include=lines.purchasable.categories")->assertOk()->json('included'));
+    $this->getJson("/store/carts/{$cartId}?include=lines.purchasable.categories")
+        ->assertStatus(Response::HTTP_BAD_REQUEST)
+        ->assertJsonPath('errors.0.code', 'bad_request');
+});
 
-    expect($included->pluck('type')->unique()->sort()->values()->all())->toBe(['cart-lines', 'products']);
+it('includes the product of a variant line through a three level include', function (): void {
+    $parent = Product::factory()->publish()->create();
+    $variant = ProductVariant::factory()->create(['product_id' => $parent->id]);
+    $variant->prices()->create(['amount' => 3000, 'currency_id' => $this->currency->id]);
+    $variant->mutateStock($this->inventory->id, 20);
+
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+    $this->postJson("/store/carts/{$cartId}/lines", ['purchasable_type' => 'product', 'purchasable_id' => $this->product->public_id])->assertOk();
+    $this->postJson("/store/carts/{$cartId}/lines", ['purchasable_type' => 'variant', 'purchasable_id' => $variant->public_id])->assertOk();
+
+    $included = collect($this->getJson("/store/carts/{$cartId}?include=lines.purchasable.product")->assertOk()->json('included'));
+
+    expect($included->pluck('type')->unique()->sort()->values()->all())->toBe(['cart-lines', 'products', 'variants'])
+        ->and($included->where('type', 'products')->pluck('id')->sort()->values()->all())->toBe(collect([$this->product->public_id, $parent->public_id])->sort()->values()->all())
+        ->and($included->firstWhere('type', 'variants')['relationships']['product']['data']['id'])->toBe($parent->public_id);
 });

--- a/tests/Api/Feature/CheckoutEndpointsTest.php
+++ b/tests/Api/Feature/CheckoutEndpointsTest.php
@@ -11,6 +11,7 @@ use Shopper\Core\Enum\DiscountRequirement;
 use Shopper\Core\Enum\DiscountType;
 use Shopper\Core\Models\Carrier;
 use Shopper\Core\Models\CarrierOption;
+use Shopper\Core\Models\Contracts\Order as OrderContract;
 use Shopper\Core\Models\Country;
 use Shopper\Core\Models\Discount;
 use Shopper\Core\Models\Inventory;
@@ -159,7 +160,7 @@ it('sets the shipping method and folds its price into the totals', function (): 
 it('rejects a shipping option the carriers do not quote', function (): void {
     $this->postJson("/store/carts/{$this->cart->public_id}/shipping-method", [
         'option_id' => 'main-carrier:does-not-exist',
-    ])->assertUnprocessable();
+    ])->assertUnprocessable()->assertJsonPath('errors.0.code', 'shipping_option_unavailable');
 });
 
 it('lists the payment methods available for the cart zone', function (): void {
@@ -190,7 +191,7 @@ it('rejects a payment method outside the cart offer', function (): void {
 
     $this->postJson("/store/carts/{$this->cart->public_id}/payment-method", [
         'payment_method_id' => (string) $elsewhere->public_id,
-    ])->assertUnprocessable();
+    ])->assertUnprocessable()->assertJsonPath('errors.0.code', 'payment_method_unavailable');
 
     expect($this->cart->refresh()->payment_method_id)->toBeNull();
 });
@@ -262,7 +263,8 @@ it('opens a fresh session when the cart total changed', function (): void {
 
 it('requires a payment method before opening a session', function (): void {
     $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")
-        ->assertUnprocessable();
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'payment_method_required');
 });
 
 it('completes the cart into an order', function (): void {
@@ -295,7 +297,8 @@ it('rejects checkout with a 422 when stock is drained after the line is added', 
     $this->product->decreaseStock($this->inventory->id, 100);
 
     $this->postJson("/store/carts/{$this->cart->public_id}/complete")
-        ->assertUnprocessable();
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'stock_insufficient');
 
     expect(Order::query()->count())->toBe(0)
         ->and($this->product->getStock())->toBe(0);
@@ -322,6 +325,7 @@ it('rejects completion when the shipping price increased since selection', funct
 
     $this->postJson("/store/carts/{$this->cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'shipping_price_changed')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/shipping_method');
 
     expect($this->cart->refresh()->isCompleted())->toBeFalse();
@@ -343,6 +347,7 @@ it('requires a shipping method to complete a shippable cart', function (): void 
 
     $this->postJson("/store/carts/{$this->cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'shipping_method_required')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/shipping_method');
 });
 
@@ -360,6 +365,7 @@ it('completes a cart of virtual products without any shipping method', function 
 it('requires a payment method to complete the cart', function (): void {
     $this->postJson("/store/carts/{$this->cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'payment_method_required')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/payment_method');
 });
 
@@ -368,6 +374,7 @@ it('rejects the completion of an empty cart', function (): void {
 
     $this->postJson("/store/carts/{$cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'cart_empty')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/cart');
 });
 
@@ -410,6 +417,7 @@ it('rejects completion when the payment session no longer matches the total', fu
 
     $this->postJson("/store/carts/{$this->cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'payment_session_mismatch')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/payment_session');
 });
 
@@ -468,6 +476,7 @@ it('keeps personal data out of the guest order lookup', function (): void {
 
     $this->getJson("/store/orders/{$orderId}?include=shippingAddress")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'include_not_allowed')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/include');
 
     $this->getJson("/store/orders/{$orderId}?include=items")->assertOk();
@@ -579,6 +588,7 @@ it('requires a shipping method when the cart mixes virtual and physical products
 
     $this->postJson("/store/carts/{$cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'shipping_method_required')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/shipping_method');
 });
 
@@ -635,6 +645,7 @@ it('requires an email to complete a guest cart', function (): void {
 
     $this->postJson("/store/carts/{$this->cart->public_id}/complete")
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'email_required')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/email');
 
     expect($this->cart->refresh()->isCompleted())->toBeFalse();
@@ -742,9 +753,26 @@ it('applies a promotion code and folds the discount into the totals', function (
     expect($this->cart->refresh()->promotions->first()->code)->toBe('SAVE20');
 });
 
+it('answers promotion_limit_reached when the code is exhausted between validation and reservation', function (): void {
+    $discount = orderDiscount(['usage_limit' => 1]);
+    readyCart($this->cart, $this->option, $this->paymentMethod);
+    $this->postJson("/store/carts/{$this->cart->public_id}/promotion", ['code' => 'SAVE20'])->assertOk();
+
+    $orderModel = resolve(OrderContract::class)::class;
+    $orderModel::created(fn () => $discount->increment('total_use'));
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/complete")
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'promotion_limit_reached');
+
+    expect(Order::query()->count())->toBe(0)
+        ->and($discount->refresh()->total_use)->toBe(0);
+});
+
 it('rejects an unknown promotion code', function (): void {
     $this->postJson("/store/carts/{$this->cart->public_id}/promotion", ['code' => 'NOPE'])
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'promotion_not_applicable')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/code');
 
     expect($this->cart->refresh()->promotions)->toBeEmpty();
@@ -816,6 +844,7 @@ it('rejects an expired promotion code', function (): void {
 
     $this->postJson("/store/carts/{$this->cart->public_id}/promotion", ['code' => 'SAVE20'])
         ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'promotion_not_applicable')
         ->assertJsonPath('errors.0.source.pointer', '/data/attributes/code');
 
     expect($this->cart->refresh()->promotions)->toBeEmpty();

--- a/tests/Api/Feature/CustomerAccountTest.php
+++ b/tests/Api/Feature/CustomerAccountTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
 use Shopper\Core\Enum\ShipmentStatus;
 use Shopper\Core\Models\Address;
+use Shopper\Core\Models\Carrier;
 use Shopper\Core\Models\Country;
 use Shopper\Core\Models\Order;
 use Shopper\Core\Models\OrderAddress;
@@ -14,6 +15,7 @@ use Shopper\Core\Models\OrderItem;
 use Shopper\Core\Models\OrderShipping;
 use Shopper\Core\Models\OrderShippingEvent;
 use Shopper\Core\Models\PaymentMethod;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\Core\Stubs\User;
 
 uses(Tests\Api\TestCase::class);
@@ -234,6 +236,29 @@ it('retrieves a customer order with its full account detail', function (): void 
     expect($events)->toHaveCount(1)
         ->and($events[0]['attributes']['location'])->toBe('Roissy Hub')
         ->and($events[0]['attributes']['status'])->toBe(ShipmentStatus::InTransit->value);
+});
+
+it('rejects an include outside the order allowlist on the account detail endpoint', function (): void {
+    $order = Order::factory()->create(['customer_id' => $this->customer->id]);
+
+    Sanctum::actingAs($this->customer, ['store']);
+
+    $this->getJson("/store/customers/me/orders/{$order->public_id}?include=items.product")
+        ->assertStatus(Response::HTTP_BAD_REQUEST)
+        ->assertJsonPath('errors.0.code', 'bad_request');
+});
+
+it('exposes the carrier name of a shipment on the account order detail endpoint', function (): void {
+    $order = Order::factory()->create(['customer_id' => $this->customer->id]);
+    $carrier = Carrier::factory()->create(['name' => 'UPS']);
+    OrderShipping::factory()->create(['order_id' => $order->id, 'carrier_id' => $carrier->id]);
+
+    Sanctum::actingAs($this->customer, ['store']);
+
+    $shipment = collect($this->getJson("/store/customers/me/orders/{$order->public_id}?include=shippings")->assertOk()->json('included'))
+        ->firstWhere('type', 'order-shippings');
+
+    expect($shipment['attributes']['carrier_name'])->toBe('UPS');
 });
 
 it('hides another customer order from the account detail endpoint', function (): void {

--- a/tests/Api/Feature/ErrorContractTest.php
+++ b/tests/Api/Feature/ErrorContractTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Hash;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Api\TestCase::class);
+
+it('names the failed rule as the error code of a validation failure', function (): void {
+    User::factory()->create(['email' => 'taken@example.com']);
+
+    $this->postJson('/store/auth/register', [
+        'last_name' => 'Doe',
+        'email' => 'taken@example.com',
+        'password' => 'super-secret-password',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'unique')
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/email');
+});
+
+it('answers a stable code when the credentials are refused', function (): void {
+    User::factory()->create(['email' => 'john@example.com', 'password' => Hash::make('correct-password')]);
+
+    $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'wrong'])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'credentials_invalid')
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/email');
+});
+
+it('answers a stable code on an invalid password reset token without revealing whether the email exists', function (): void {
+    User::factory()->create(['email' => 'john@example.com']);
+
+    $known = $this->postJson('/store/auth/reset-password', [
+        'email' => 'john@example.com',
+        'token' => 'not-a-token',
+        'password' => 'brand-new-password',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'reset_token_invalid');
+
+    $unknown = $this->postJson('/store/auth/reset-password', [
+        'email' => 'nobody@example.com',
+        'token' => 'not-a-token',
+        'password' => 'brand-new-password',
+    ])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'reset_token_invalid');
+
+    expect($unknown->json('errors.0.detail'))->toBe($known->json('errors.0.detail'));
+});
+
+it('pairs each message of a field with the rule it failed', function (): void {
+    $errors = collect($this->postJson('/store/auth/register', [
+        'last_name' => 'Doe',
+        'email' => str_repeat('a', 260),
+        'password' => 'super-secret-password',
+    ])->assertUnprocessable()->json('errors'))
+        ->where('source.pointer', '/data/attributes/email')
+        ->pluck('code')
+        ->values()
+        ->all();
+
+    expect($errors)->toBe(['email', 'max']);
+});
+
+it('keeps the rate limit headers on a throttled request', function (): void {
+    $attempts = (int) config('shopper.http.rate_limiters.shopper-api-auth');
+
+    for ($attempt = 0; $attempt < $attempts; $attempt++) {
+        $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'wrong'])->assertUnprocessable();
+    }
+
+    $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'wrong'])
+        ->assertStatus(Response::HTTP_TOO_MANY_REQUESTS)
+        ->assertJsonPath('errors.0.code', 'rate_limited')
+        ->assertHeader('Retry-After');
+});
+
+it('never names the model class in a not found detail', function (): void {
+    $response = $this->getJson('/store/products/unknown-slug')
+        ->assertNotFound()
+        ->assertJsonPath('errors.0.code', 'not_found');
+
+    expect($response->json('errors.0.detail'))->not->toContain('Shopper\\');
+});
+
+it('rejects an expired token', function (): void {
+    $token = $this->postJson('/store/auth/register', [
+        'last_name' => 'Doe',
+        'email' => 'jane@example.com',
+        'password' => 'super-secret-password',
+    ])->assertCreated()->json('meta.token');
+
+    $this->travelTo(now()->addMinutes((int) config('shopper.api.token_expiration') + 1));
+
+    $this->getJson('/store/customers/me', ['Authorization' => 'Bearer '.$token])
+        ->assertUnauthorized()
+        ->assertJsonPath('errors.0.code', 'unauthenticated')
+        ->assertJsonPath('errors.0.status', '401');
+});
+
+it('names the password rule as the error code on a weak password', function (): void {
+    $this->postJson('/store/auth/register', ['last_name' => 'Doe', 'email' => 'jane@example.com', 'password' => '123'])
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'password')
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/password');
+});
+
+it('writes a nested field as JSON pointer segments', function (): void {
+    $this->getJson('/store/products?filter[currency]=NOPE')
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'currency_unknown')
+        ->assertJsonPath('errors.0.source.pointer', '/data/attributes/filter/currency');
+});
+
+it('never expires a token when no expiration is configured', function (): void {
+    config(['shopper.api.token_expiration' => null]);
+
+    $token = $this->postJson('/store/auth/register', [
+        'last_name' => 'Doe',
+        'email' => 'jane@example.com',
+        'password' => 'super-secret-password',
+    ])->assertCreated()->json('meta.token');
+
+    $this->travelTo(now()->addYears(5));
+
+    $this->getJson('/store/customers/me', ['Authorization' => 'Bearer '.$token])->assertOk();
+});

--- a/tests/Cart/Feature/CartManagerTest.php
+++ b/tests/Cart/Feature/CartManagerTest.php
@@ -6,6 +6,7 @@ use Shopper\Cart\CartManager;
 use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Exceptions\InsufficientStockException;
 use Shopper\Cart\Exceptions\InvalidDiscountException;
+use Shopper\Cart\Exceptions\MissingPriceException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartLine;
 use Shopper\Core\Enum\DiscountApplyTo;
@@ -44,6 +45,13 @@ beforeEach(function (): void {
 });
 
 describe(CartManager::class, function (): void {
+    it('refuses to add a purchasable without a price in the cart currency', function (): void {
+        $unpriced = Product::factory()->standard()->create();
+        $unpriced->mutateStock($this->inventory->id, 10);
+
+        $this->cartManager->add($this->cart, $unpriced);
+    })->throws(MissingPriceException::class);
+
     it('adds a product to the cart', function (): void {
         $line = $this->cartManager->add($this->cart, $this->product);
 
@@ -103,6 +111,7 @@ describe(CartManager::class, function (): void {
             'currency_id' => $this->currency->id,
         ]);
         $product2->mutateStock($this->inventory->id, 10);
+        $product2->refresh();
 
         $this->cartManager->add($this->cart, $this->product);
         $this->cartManager->add($this->cart, $product2);

--- a/tests/Cart/Feature/CartMergeTest.php
+++ b/tests/Cart/Feature/CartMergeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Shopper\Cart\CartManager;
 use Shopper\Cart\CartSessionManager;
+use Shopper\Cart\Exceptions\MissingPriceException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Enum\PromotionSource;
 use Shopper\Core\Models\Currency;
@@ -52,12 +53,34 @@ describe('CartManager::merge', function (): void {
 
         $this->cartManager->add($this->guestCart, $other, quantity: 1);
         $this->cartManager->add($this->userCart, $this->product, quantity: 1);
+        $this->userCart->update(['shipping_option_id' => 'main-carrier:standard', 'shipping_amount' => 500]);
+        $this->cartManager->setPaymentSession($this->userCart, ['reference' => 'pi_1', 'amount' => 1500]);
 
         $merged = $this->cartManager->merge($this->guestCart, $this->userCart);
 
         expect($merged->lines()->count())->toBe(2)
-            ->and($merged->lines()->pluck('purchasable_id'))->toContain($other->id);
+            ->and($merged->lines()->pluck('purchasable_id'))->toContain($other->id)
+            ->and($merged->shipping_option_id)->toBeNull()
+            ->and($merged->shipping_amount)->toBeNull()
+            ->and($merged->payment_session)->toBeNull();
     });
+
+    it('is a no-op when the source cart is gone by the time the lock is acquired', function (): void {
+        $this->cartManager->add($this->userCart, $this->product, quantity: 1);
+        $this->guestCart->delete();
+
+        $merged = $this->cartManager->merge($this->guestCart, $this->userCart);
+
+        expect($merged->is($this->userCart))->toBeTrue()
+            ->and($merged->lines()->first()->quantity)->toBe(1);
+    });
+
+    it('refuses a line without a price in the target currency', function (): void {
+        $eurCart = Cart::factory()->create(['currency_code' => 'EUR', 'customer_id' => $this->user->id]);
+        $this->cartManager->add($this->guestCart, $this->product, quantity: 1);
+
+        $this->cartManager->merge($this->guestCart, $eurCart);
+    })->throws(MissingPriceException::class);
 
     it('re-prices moved lines when the carts use different currencies', function (): void {
         $eur = Currency::query()->where('code', 'EUR')->first();
@@ -105,6 +128,21 @@ describe('CartSessionManager::associate', function (): void {
 
         expect($session->current()->id)->toBe($this->userCart->id)
             ->and($this->userCart->lines()->first()->quantity)->toBe(3);
+    });
+
+    it('claims the session cart whole when a line has no price in the currency of the cart the user owns', function (): void {
+        $user = User::factory()->create();
+        Cart::factory()->create(['currency_code' => 'EUR', 'customer_id' => $user->id]);
+        $session = resolve(CartSessionManager::class);
+        $session->use($this->guestCart);
+
+        $this->cartManager->add($this->guestCart, $this->product, quantity: 2);
+
+        $session->associate($user);
+
+        expect($session->current()->id)->toBe($this->guestCart->id)
+            ->and($this->guestCart->refresh()->customer_id)->toBe($user->id)
+            ->and($this->guestCart->lines()->first()->unit_price_amount)->toBe(1000);
     });
 
     it('attaches the session cart when the user owns no cart', function (): void {


### PR DESCRIPTION
## Summary

Store API and SDK changes requested by the storefront work on the Next.js starter kit: nested includes on carts, cart attachment at authentication, token expiration, and a stable machine code on every error object.

## What changed

- **Cart includes.** Cart responses were serialized from a fixed eager load and never read the `include` parameter, so a deeper path such as `include=lines.purchasable.product` answered 200 without the product, and an unknown include was never rejected. Carts now have their own allowlist (`resources.cart.includes`: `lines`, `lines.purchasable`, `lines.purchasable.product`, `addresses`, `paymentMethod`), an unknown include answers the same 400 as the catalog, and the purchasables are eager loaded through `morphWith` with their prices, media and, when requested, product, so a cart mixing product and variant lines serializes in a fixed number of queries instead of three per line. The account order detail endpoint validates its includes the same way, with `shippings.carrier` loaded through `include_loads`, also when only `shippings.events` is requested.
- **Resources config merge.** Laravel merges a published config file on its top level only, so a `config/shopper/api.php` published before this change hid the whole `resources.cart` entry and the new `resources.order.include_loads` key: every cart include answered 400 with an empty allowlist. `ApiServiceProvider` now merges the resources registry one level deeper. A resource or key missing from the published file takes the package default, a resource the file declares keeps authority over the keys it declares, and adding a resource to the package no longer requires republishing.
- **Cart attachment at authentication.** `POST /store/auth/register` and `POST /store/auth/login` accept an optional `cart_id`. The guest cart is attached under a row lock and folded into the cart the customer already owns through `TransferCartAction`. `meta.cart_id` is the customer's open cart after the call, so a retried login answers the surviving cart even though the guest cart is gone, and a fresh device learns the cart it should use. An unknown, completed or foreign cart is ignored: the cart never makes the authentication fail. When a guest line has no price in the currency of the cart the customer already owns, the guest cart is claimed whole instead of merged, so nothing the customer picked disappears at sign in; `Cart::associate()` on the session cart does the same. Transferring a completed guest cart now answers 409 instead of 500.
- **Cart merge.** A line moved between carts of different currencies used to be re-priced to 0 when the purchasable had no price in the target currency, and the same fallback existed when adding a line or switching currency. The cart manager now throws `MissingPriceException`, answered as 422 `price_missing` when adding a line or switching currency. The merge re-reads both carts under lock, so two concurrent logins with the same cart do not double the quantities and a cart completed meanwhile is refused; the target's lines are read once instead of once per moved line, and its shipping choice and payment session are dropped once its contents changed, as a currency switch already did. The customer's cart is picked deterministically.
- **Token expiration.** Customer tokens expire after `shopper.api.token_expiration` minutes, 30 days by default, null for no expiration. Expired tokens are pruned daily through `sanctum:prune-expired`.
- **Error codes.** Every JSON:API error object carries a `code`, snake_case and never translated. A validation failure names the failed rule (`unique`, `email`, `required`, `password`) next to the field pointer; the errors raised by the API itself carry a domain code from the `ErrorCode` enum through `ApiValidationException::withCode()` and `ApiException`: `credentials_invalid`, `reset_token_invalid`, `stock_insufficient`, `cart_completed`, `payment_method_required` and the others. HTTP errors carry `unauthenticated`, `forbidden`, `not_found`, `rate_limited`. A failed password reset answers the same detail whether or not the email exists, in line with the blind 202 of the reset link request. A coupon that reaches its usage limit during checkout answers `promotion_limit_reached` instead of a 500. The renderer keeps the `Retry-After` and rate limit headers on a 429, no longer names the model class in a 404 detail, and writes nested keys as JSON pointer segments.
- **SDK.** `RegisterPayload` and `LoginPayload` accept `cart_id`, `auth.getCartId()` exposes the customer's cart after authentication. `ShopperConfig.onUnauthorized` is called once on a 401 answered to a request that carried an Authorization header, after the token storage is cleared. `ShopperApiError.code`, `ShopperApiError.fields()` and `ShopperApiError.codeFor(field)` read the new contract, the last one answering the code of a given field whatever the error order. `JsonApiError` gains `code`. The SDK gets its first test suite, on vitest.

## Upgrade notes

- A published `config/shopper/api.php` needs no change: `resources.cart` and `resources.order.include_loads` come from the package when the published file does not declare them. A published `resources.order.includes` stays authoritative, so add `shippingAddress`, `billingAddress`, `paymentMethod`, `shippings`, `shippings.events` and `refund` to it to expose them.
- `include` values outside the cart allowlist answer 400 on every cart endpoint; a nested path must be declared in full in `shopper.api.resources.cart.includes`.
- Customer tokens issued from now on expire after 30 days; set `SHOPPER_API_TOKEN_EXPIRATION` or `shopper.api.token_expiration` to change it, `null` disables it. Tokens issued before this release keep no expiration.
- A resource key omitted from a published `resources` entry now takes the package default; set it to `[]` explicitly to disable it.
- `sanctum:prune-expired` is scheduled daily by the package; a host scheduling it too runs it twice, harmlessly.
- The SDK clears its token storage on a 401 answered to an authenticated request, whether or not `onUnauthorized` is configured.
- Every error object now has a `code` member, and the pointer of a nested field uses slashes: `/data/attributes/filter/currency`.
- Adding a line or switching the cart currency throws `MissingPriceException` when a purchasable has no price in the target currency, where a line at 0 was written before; merging carts through `TransferCartAction` or `Cart::associate()` claims the guest cart instead. Callers of `CartManager::merge()` directly must handle the exception.
- `CartManager::merge()` resets the target's shipping option, shipping amount and payment session once lines moved in.
