### PR TITLE
fix(api): report payment session failures as 503 and throttle failed logins per email

### DIFF
--- a/packages/api/resources/lang/en/messages.php
+++ b/packages/api/resources/lang/en/messages.php
@@ -32,8 +32,11 @@ return [
         'method_required' => 'Set a payment method on the cart before completing it.',
         'method_required_for_session' => 'Set a payment method on the cart before opening a payment session.',
         'method_not_available' => 'This payment method is not available for the cart.',
-        'method_not_configured' => 'The ":method" payment method is not configured.',
+        'method_not_configured' => 'The ":method" payment method is not configured. Choose another payment method.',
+        'provider_unavailable' => 'The payment provider could not open the payment session. Try again in a moment.',
         'session_mismatch' => 'The payment session no longer matches the cart total. Create a new payment session and try again.',
+        'session_in_progress' => 'Another request is opening the payment session for this cart. Try again in a moment.',
+        'session_required' => 'Open a payment session before completing the cart.',
     ],
 
     'order' => [

--- a/packages/api/resources/lang/es/messages.php
+++ b/packages/api/resources/lang/es/messages.php
@@ -32,8 +32,11 @@ return [
         'method_required' => 'Selecciona un método de pago antes de completar el carrito.',
         'method_required_for_session' => 'Selecciona un método de pago antes de abrir una sesión de pago.',
         'method_not_available' => 'Este método de pago no está disponible para el carrito.',
-        'method_not_configured' => 'El método de pago «:method» no está configurado.',
+        'method_not_configured' => 'El método de pago «:method» no está configurado. Elige otro método de pago.',
+        'provider_unavailable' => 'El proveedor de pagos no pudo abrir la sesión de pago. Inténtalo de nuevo en un momento.',
         'session_mismatch' => 'La sesión de pago ya no coincide con el total del carrito. Crea una nueva sesión de pago e inténtalo de nuevo.',
+        'session_in_progress' => 'Otra solicitud está abriendo la sesión de pago de este carrito. Inténtalo de nuevo en un momento.',
+        'session_required' => 'Abre una sesión de pago antes de completar el carrito.',
     ],
 
     'order' => [

--- a/packages/api/resources/lang/fr/messages.php
+++ b/packages/api/resources/lang/fr/messages.php
@@ -32,8 +32,11 @@ return [
         'method_required' => 'Choisissez un moyen de paiement avant de finaliser le panier.',
         'method_required_for_session' => 'Choisissez un moyen de paiement avant d\'ouvrir une session de paiement.',
         'method_not_available' => 'Ce moyen de paiement n\'est pas disponible pour le panier.',
-        'method_not_configured' => 'Le moyen de paiement « :method » n\'est pas configuré.',
+        'method_not_configured' => 'Le moyen de paiement « :method » n\'est pas configuré. Choisissez un autre moyen de paiement.',
+        'provider_unavailable' => 'Le prestataire de paiement n\'a pas pu ouvrir la session de paiement. Réessayez dans un instant.',
         'session_mismatch' => 'La session de paiement ne correspond plus au total du panier. Créez une nouvelle session de paiement et réessayez.',
+        'session_in_progress' => 'Une autre requête ouvre la session de paiement de ce panier. Réessayez dans un instant.',
+        'session_required' => 'Ouvrez une session de paiement avant de finaliser le panier.',
     ],
 
     'order' => [

--- a/packages/api/resources/lang/sv/messages.php
+++ b/packages/api/resources/lang/sv/messages.php
@@ -32,8 +32,11 @@ return [
         'method_required' => 'Välj ett betalsätt för varukorgen innan den slutförs.',
         'method_required_for_session' => 'Välj ett betalsätt för varukorgen innan en betalsession öppnas.',
         'method_not_available' => 'Detta betalsätt är inte tillgängligt för varukorgen.',
-        'method_not_configured' => 'Betalsättet ":method" är inte konfigurerat.',
+        'method_not_configured' => 'Betalsättet ":method" är inte konfigurerat. Välj ett annat betalsätt.',
+        'provider_unavailable' => 'Betalleverantören kunde inte öppna betalsessionen. Försök igen om en stund.',
         'session_mismatch' => 'Betalsessionen matchar inte längre varukorgens totalbelopp. Skapa en ny betalsession och försök igen.',
+        'session_in_progress' => 'En annan begäran öppnar betalsessionen för denna varukorg. Försök igen om en stund.',
+        'session_required' => 'Öppna en betalsession innan varukorgen slutförs.',
     ],
 
     'order' => [

--- a/packages/api/src/Actions/CompleteCartAction.php
+++ b/packages/api/src/Actions/CompleteCartAction.php
@@ -197,18 +197,17 @@ final readonly class CompleteCartAction
         }
     }
 
-    /**
-     * An open payment session must match what the order will charge, in
-     * amount and in currency: a total or a currency that moved since the
-     * intent was created would collect the wrong money. Runs under the cart
-     * lock against the exact total the order freezes. The client recreates
-     * the session against the new total and retries.
-     */
     private function guardPaymentSession(Cart $cart, int $total): void
     {
         $session = $cart->payment_session;
 
         if (! $session || ! isset($session['amount'])) {
+            if (($cart->paymentMethod->driver ?? 'manual') !== 'manual') {
+                throw ApiValidationException::withCode(ErrorCode::PaymentSessionRequired, [
+                    'payment_session' => __('shopper-api::messages.payment.session_required'),
+                ]);
+            }
+
             return;
         }
 

--- a/packages/api/src/Actions/CreateCartPaymentSessionAction.php
+++ b/packages/api/src/Actions/CreateCartPaymentSessionAction.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Actions;
 
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 use Shopper\Api\Support\PaymentSession;
 use Shopper\Cart\CartManager;
+use Shopper\Cart\Exceptions\CartCompletedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Http\Enum\ErrorCode;
+use Shopper\Http\Exceptions\ApiException;
 use Shopper\Http\Exceptions\ApiValidationException;
 use Shopper\Payment\Contracts\PaymentDriver;
 use Shopper\Payment\Exceptions\PaymentException;
 use Shopper\Payment\PaymentManager;
+use Symfony\Component\HttpFoundation\Response;
 
 final readonly class CreateCartPaymentSessionAction
 {
@@ -21,6 +27,13 @@ final readonly class CreateCartPaymentSessionAction
         private CancelPaymentSessionAction $cancelSession,
     ) {}
 
+    /**
+     * One collectable intent per cart: concurrent calls are serialized on
+     * the cart, so a call that waited resumes what the previous one opened
+     * when the driver can retrieve it, instead of opening its own. The lock
+     * lives in a shared cache store, never on the cart row, as it spans the
+     * round trip to the provider.
+     */
     public function execute(Cart $cart): PaymentSession
     {
         $method = $cart->paymentMethod;
@@ -32,54 +45,48 @@ final readonly class CreateCartPaymentSessionAction
         }
 
         $driverCode = $method->driver ?? 'manual';
+
+        if (! $this->paymentManager->isConfigured($driverCode)) {
+            report(PaymentException::notConfigured($driverCode));
+
+            throw new ApiException(
+                Response::HTTP_SERVICE_UNAVAILABLE,
+                ErrorCode::PaymentMethodNotConfigured,
+                __('shopper-api::messages.payment.method_not_configured', ['method' => $method->title]),
+            );
+        }
+
         $driver = $this->paymentManager->driver($driverCode);
 
-        if (! $driver->isConfigured()) {
-            throw ApiValidationException::withCode(ErrorCode::PaymentMethodNotConfigured, [
-                'payment_method' => __('shopper-api::messages.payment.method_not_configured', ['method' => $method->title]),
-            ]);
+        try {
+            return Cache::lock("cart:payment-session:{$cart->public_id}", 90)->block(3, function () use ($cart, $driver, $driverCode): PaymentSession {
+                $cart->unsetRelations()->refresh();
+
+                if ($cart->isCompleted()) {
+                    throw new ApiException(Response::HTTP_CONFLICT, ErrorCode::CartCompleted, (new CartCompletedException)->getMessage());
+                }
+
+                $amount = $this->cartManager->calculate($cart)->total;
+
+                if ($amount <= 0) {
+                    throw ApiValidationException::withCode(ErrorCode::CartNothingToCollect, [
+                        'cart' => __('shopper-api::messages.cart.nothing_to_collect'),
+                    ]);
+                }
+
+                return $this->resumeSession($cart, $driver, $driverCode, $amount)
+                    ?? $this->openSession($cart, $driver, $driverCode, $amount);
+            });
+        } catch (LockTimeoutException $exception) {
+            report($exception);
+
+            throw new ApiException(
+                Response::HTTP_CONFLICT,
+                ErrorCode::PaymentSessionInProgress,
+                __('shopper-api::messages.payment.session_in_progress'),
+                ['Retry-After' => 3],
+            );
         }
-
-        $amount = $this->cartManager->calculate($cart)->total;
-
-        if ($amount <= 0) {
-            throw ApiValidationException::withCode(ErrorCode::CartNothingToCollect, [
-                'cart' => __('shopper-api::messages.cart.nothing_to_collect'),
-            ]);
-        }
-
-        $existing = $this->resumeSession($cart, $driver, $driverCode, $amount);
-
-        if ($existing) {
-            return $existing;
-        }
-
-        $this->cancelSession->execute($cart->payment_session);
-
-        // The idempotency key is versioned per attempt, never derived from the
-        // amount: providers cache responses by key (Stripe: 24h), so an
-        // amount-based key would resurrect a stale intent when a cart total
-        // round-trips back to a previous value.
-        $version = (int) ($cart->payment_session['version'] ?? 0) + 1;
-
-        $result = $driver->initiatePayment(
-            amount: $amount,
-            currency: $cart->currency_code,
-            context: [
-                'idempotency_key' => "cart_{$cart->public_id}_v{$version}",
-                'metadata' => ['cart_id' => (string) $cart->public_id],
-            ],
-        );
-
-        $this->cartManager->setPaymentSession($cart, [
-            'driver' => $driverCode,
-            'reference' => $result->reference,
-            'amount' => $amount,
-            'currency' => $cart->currency_code,
-            'version' => $version,
-        ]);
-
-        return new PaymentSession($cart, $driverCode, $result);
     }
 
     /**
@@ -113,5 +120,55 @@ final readonly class CreateCartPaymentSessionAction
         }
 
         return new PaymentSession($cart, $driverCode, $result);
+    }
+
+    /**
+     * The new intent is opened under a key never shared between attempts,
+     * as the provider replays the saved outcome of a key for a day, errors
+     * included, and refuses it with other parameters. It is stored before
+     * the previous intent is cancelled, so the cart never points at nothing:
+     * a failed initiation leaves the previous session in place, where a
+     * completion still checks its amount. A response lost after the provider
+     * opened the intent leaves it unconfirmed there, which collects nothing.
+     */
+    private function openSession(Cart $cart, PaymentDriver $driver, string $driverCode, int $amount): PaymentSession
+    {
+        $previous = $cart->payment_session;
+
+        try {
+            $result = $driver->initiatePayment(
+                amount: $amount,
+                currency: $cart->currency_code,
+                context: [
+                    'idempotency_key' => "cart_{$cart->public_id}_".Str::ulid(),
+                    'metadata' => ['cart_id' => (string) $cart->public_id],
+                ],
+            );
+        } catch (PaymentException $exception) {
+            report($exception);
+
+            throw $this->providerUnavailable();
+        }
+
+        $this->cartManager->setPaymentSession($cart, [
+            'driver' => $driverCode,
+            'reference' => $result->reference,
+            'amount' => $amount,
+            'currency' => $cart->currency_code,
+        ]);
+
+        $this->cancelSession->execute($previous);
+
+        return new PaymentSession($cart, $driverCode, $result);
+    }
+
+    private function providerUnavailable(): ApiException
+    {
+        return new ApiException(
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            ErrorCode::PaymentProviderUnavailable,
+            __('shopper-api::messages.payment.provider_unavailable'),
+            ['Retry-After' => 5],
+        );
     }
 }

--- a/packages/api/src/Console/InstallCommand.php
+++ b/packages/api/src/Console/InstallCommand.php
@@ -154,6 +154,7 @@ final class InstallCommand extends Command
         note(implode("\n", [
             "→ Your storefront endpoints live under /{$prefix}",
             '→ Pin a pricing zone per request with the X-Shopper-Zone header',
+            '→ Calling from a server-side storefront? Forward the visitor IP in X-Forwarded-For and trust it with trustProxies()',
             '→ Consume the API with: npm install @shopperlabs/shopper-sdk',
         ]));
 

--- a/packages/api/src/Http/Controllers/Auth/AuthenticationController.php
+++ b/packages/api/src/Http/Controllers/Auth/AuthenticationController.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Shopper\Api\Http\Controllers\Auth;
 
+use Illuminate\Auth\Events\Lockout;
+use Illuminate\Cache\RateLimiter;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use Laravel\Sanctum\NewAccessToken;
 use Laravel\Sanctum\PersonalAccessToken;
 use RuntimeException;
@@ -31,6 +35,7 @@ final class AuthenticationController
     public function __construct(
         private readonly DatabaseManager $database,
         private readonly TransferCartAction $transferCart,
+        private readonly RateLimiter $limiter,
     ) {}
 
     /**
@@ -57,17 +62,35 @@ final class AuthenticationController
         return $response->setStatusCode(Response::HTTP_CREATED);
     }
 
+    /**
+     * Failed logins are counted per email and origin, the key Laravel's own
+     * login throttling uses: an attacker cannot lock a customer out from
+     * another address. A successful login clears the count.
+     */
     public function login(LoginRequest $request): JsonResponse
     {
+        $email = $request->string('email')->toString();
+        $throttleKey = 'shopper:login:'.sha1(Str::transliterate(Str::lower($email)).'|'.$request->ip());
+
+        if ($this->limiter->tooManyAttempts($throttleKey, $this->loginFailures())) {
+            event(new Lockout($request));
+
+            throw $this->throttled($throttleKey);
+        }
+
         /** @var class-string<Model&Authenticatable> $model */
         $model = (string) config('auth.providers.users.model');
 
         /** @var (Model&Authenticatable)|null $customer */
-        $customer = $model::query()->where('email', $request->string('email')->toString())->first();
+        $customer = $model::query()->firstWhere('email', $email);
 
         if ($customer === null || ! Hash::check($request->string('password')->toString(), $customer->getAuthPassword())) {
+            $this->limiter->hit($throttleKey);
+
             throw ApiValidationException::withCode(ErrorCode::CredentialsInvalid, ['email' => __('auth.failed')]);
         }
+
+        $this->limiter->clear($throttleKey);
 
         /** @var JsonResponse $response */
         $response = CustomerResource::make($customer)
@@ -134,6 +157,22 @@ final class AuthenticationController
             ->first();
 
         return $cart === null ? null : $this->transferCart->execute($cart, (int) $customer->getAuthIdentifier());
+    }
+
+    private function throttled(string $key): ThrottleRequestsException
+    {
+        $seconds = $this->limiter->availableIn($key);
+
+        return new ThrottleRequestsException(
+            __('auth.throttle', ['seconds' => $seconds, 'minutes' => (int) ceil($seconds / 60)]),
+            null,
+            ['Retry-After' => $seconds],
+        );
+    }
+
+    private function loginFailures(): int
+    {
+        return (int) config('shopper.http.login_failures', 5);
     }
 
     private function issueToken(Model&Authenticatable $customer): string

--- a/packages/api/src/Http/Controllers/Cart/CartPaymentMethodController.php
+++ b/packages/api/src/Http/Controllers/Cart/CartPaymentMethodController.php
@@ -6,6 +6,7 @@ namespace Shopper\Api\Http\Controllers\Cart;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Shopper\Api\Actions\CancelPaymentSessionAction;
 use Shopper\Api\Concerns\RespondsWithCart;
 use Shopper\Api\Http\Requests\Cart\SetPaymentMethodRequest;
 use Shopper\Api\Http\Resources\JsonApiResource;
@@ -27,6 +28,7 @@ final class CartPaymentMethodController
         private readonly PaymentProcessingService $paymentService,
         private readonly PaymentManager $paymentManager,
         private readonly CartManager $cartManager,
+        private readonly CancelPaymentSessionAction $cancelSession,
     ) {}
 
     /**
@@ -46,7 +48,9 @@ final class CartPaymentMethodController
      * Set the payment method of a cart.
      *
      * The method is referenced by its public id, as listed by the payment
-     * methods endpoint. A method outside the cart's offer is rejected.
+     * methods endpoint. A method outside the cart's offer is rejected. A
+     * session opened for the previous method is dropped and its intent
+     * cancelled, so an order never journals a reference of another method.
      */
     public function store(SetPaymentMethodRequest $request, string $cartId): JsonApiResource
     {
@@ -63,7 +67,13 @@ final class CartPaymentMethodController
             ]);
         }
 
+        $previous = $cart->payment_session;
+
         $this->mutateCart(fn () => $this->cartManager->setPaymentMethod($cart, $method->id));
+
+        if ($cart->payment_session === null) {
+            $this->cancelSession->execute($previous);
+        }
 
         return $this->cartResource($cart->refresh());
     }

--- a/packages/cart/src/Actions/CreateOrderFromCartAction.php
+++ b/packages/cart/src/Actions/CreateOrderFromCartAction.php
@@ -18,7 +18,6 @@ use Shopper\Cart\Exceptions\PriceChangedException;
 use Shopper\Cart\Models\Cart;
 use Shopper\Cart\Models\CartAddress;
 use Shopper\Cart\Models\CartPromotion;
-use Shopper\Cart\Models\Contracts\Cart as CartContract;
 use Shopper\Cart\Pipelines\CartPipelineContext;
 use Shopper\Core\Actions\ReserveCampaignBudget;
 use Shopper\Core\Contracts\Priceable;
@@ -57,8 +56,11 @@ final readonly class CreateOrderFromCartAction
     public function execute(Cart $cart, ?Closure $assertTotals = null, ?Closure $afterCreate = null): Order
     {
         return DB::transaction(function () use ($cart, $assertTotals, $afterCreate): Order {
-            /** @var Cart $cart */
-            $cart = resolve(CartContract::class)::query()->lockForUpdate()->findOrFail($cart->id);
+            $cart->setRawAttributes(
+                $cart->newQueryWithoutScopes()->lockForUpdate()->findOrFail($cart->getKey())->getAttributes(),
+                true,
+            );
+            $cart->unsetRelations();
 
             if ($cart->isCompleted()) {
                 throw new CartCompletedException;
@@ -223,12 +225,6 @@ final readonly class CreateOrderFromCartAction
         }
     }
 
-    /**
-     * A flat-rate option id is `{carrier_code}:{carrier_option_public_id}`,
-     * so the carrier option row can be linked back on the order. Live carrier
-     * rates have no local row and leave the foreign key empty; the frozen
-     * shipping_amount remains the source of truth for what was charged.
-     */
     private function resolveCarrierOptionId(?string $shippingOptionId): ?int
     {
         if (! $shippingOptionId || ! str_contains($shippingOptionId, ':')) {
@@ -241,12 +237,7 @@ final readonly class CreateOrderFromCartAction
     }
 
     /**
-     * Reserve and snapshot every applied promotion once the order exists: bump
-     * each code's usage counter atomically (throwing on a limit lost to a race
-     * or a per-customer reuse), record a per-promotion snapshot on the order, and
-     * draw down each parent campaign budget once per campaign (summed across its
-     * promotions). All keyed to the order, so a retried checkout cannot double
-     * reserve.
+     * Reserve and snapshot every applied promotion once the order exists
      *
      * @param  Collection<int, CartPromotion>  $applied
      */

--- a/packages/cart/src/CartManager.php
+++ b/packages/cart/src/CartManager.php
@@ -137,14 +137,6 @@ final readonly class CartManager
         return $context;
     }
 
-    /**
-     * The read path of the cart totals: rebuilds the pipeline context from the
-     * rows the last calculation persisted, without a single write. A cart that
-     * was mutated since (invalidated) or whose totals aged past the freshness
-     * window is recalculated once, so a time-bound automatic promotion can
-     * never stay displayed forever. Checkout never uses this path: the money
-     * charged is always recomputed under the cart lock.
-     */
     public function totals(Cart $cart): CartPipelineContext
     {
         $ttl = (int) config('shopper.cart.totals_ttl_minutes', 15);
@@ -195,7 +187,7 @@ final readonly class CartManager
     /**
      * Bind a delivery choice to the cart. The option id is the composite
      * `{carrier_code}:{service_code}` quoted by the shipping options endpoint
-     * and the amount is the server-resolved price, never a client value.
+     * and the amount is the server-resolved price.
      */
     public function setShippingMethod(Cart $cart, string $optionId, int $amount): void
     {
@@ -211,6 +203,10 @@ final readonly class CartManager
     public function setPaymentMethod(Cart $cart, int $paymentMethodId): void
     {
         $this->guardCompleted($cart);
+
+        if ((int) $cart->payment_method_id !== $paymentMethodId) {
+            $cart->setAttribute('payment_session', null);
+        }
 
         $cart->update(['payment_method_id' => $paymentMethodId]);
     }
@@ -242,10 +238,7 @@ final readonly class CartManager
     }
 
     /**
-     * Re-price the cart in another currency. Each line's unit price is resolved
-     * again from its purchasable, and the frozen checkout choices that are
-     * bound to the old currency (shipping price, payment session) are dropped
-     * so they are quoted again against the new total.
+     * Re-price the cart in another currency.
      */
     public function changeCurrency(Cart $cart, string $currencyCode): void
     {
@@ -285,18 +278,7 @@ final readonly class CartManager
     }
 
     /**
-     * Fold a guest cart into the cart a customer already owns, the standard
-     * expectation when signing in mid shopping. Quantities of the same
-     * purchasable are summed, other lines move over re-priced in the target
-     * currency, applied code promotions carry over without duplicating, and
-     * the emptied source cart is deleted. Stock is not guarded here: the
-     * checkout reservation remains the gate, exactly as for a stale cart. A
-     * line without a price in the target currency refuses the merge rather
-     * than moving for free. Both carts are re-read under lock: a concurrent
-     * merge of the same source is a no-op instead of a double count, and a
-     * target completed meanwhile is refused. The target's shipping choice
-     * and payment session are dropped once its contents changed, so they
-     * are quoted again.
+     * Fold a guest cart into the cart a customer already owns
      *
      * @throws Throwable
      */
@@ -395,8 +377,7 @@ final readonly class CartManager
     }
 
     /**
-     * Remove a code promotion from the cart. A null code clears every applied
-     * code promotion; a given code removes only that one.
+     * Remove a code promotion from the cart
      */
     public function removeCoupon(Cart $cart, ?string $code = null): void
     {

--- a/packages/http/config/http.php
+++ b/packages/http/config/http.php
@@ -23,9 +23,11 @@ return [
     |--------------------------------------------------------------------------
     |
     | Max attempts per minute for each named limiter. Keyed by the RateLimit
-    | enum so the names stay searchable and type-safe. Tune these per traffic
-    | profile; the auth and webhook surfaces are keyed by IP, the others by
-    | the authenticated customer when available.
+    | enum so the names stay searchable and type-safe. The auth and webhook
+    | surfaces are keyed by IP, the others by the authenticated customer when
+    | available. A storefront calling from its own server must forward the
+    | visitor IP (X-Forwarded-For) and be trusted in bootstrap/app.php, or
+    | every visitor shares one quota.
     |
     */
     'rate_limiters' => [
@@ -34,6 +36,20 @@ return [
         RateLimit::Checkout->value => 30,
         RateLimit::Webhook->value => 120,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Login failures
+    |--------------------------------------------------------------------------
+    |
+    | Failed logins allowed per email and per origin within a minute, the
+    | key Laravel's own login throttling uses: an attacker cannot lock a
+    | customer out from another address, and a successful login clears the
+    | count before the limit is reached. Behind a server-side storefront the
+    | origin is the visitor IP it forwards, see the rate limiters above.
+    |
+    */
+    'login_failures' => 5,
 
     /*
     |--------------------------------------------------------------------------

--- a/packages/http/src/Enum/ErrorCode.php
+++ b/packages/http/src/Enum/ErrorCode.php
@@ -47,7 +47,10 @@ enum ErrorCode: string
     case PaymentMethodRequired = 'payment_method_required';
     case PaymentMethodUnavailable = 'payment_method_unavailable';
     case PaymentMethodNotConfigured = 'payment_method_not_configured';
+    case PaymentProviderUnavailable = 'payment_provider_unavailable';
     case PaymentSessionMismatch = 'payment_session_mismatch';
+    case PaymentSessionInProgress = 'payment_session_in_progress';
+    case PaymentSessionRequired = 'payment_session_required';
 
     case AvatarInvalid = 'avatar_invalid';
 

--- a/packages/http/src/Exceptions/ApiException.php
+++ b/packages/http/src/Exceptions/ApiException.php
@@ -9,11 +9,15 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class ApiException extends HttpException
 {
+    /**
+     * @param  array<string, string|int>  $headers
+     */
     public function __construct(
         int $status,
         public readonly ErrorCode $errorCode,
         string $message = '',
+        array $headers = [],
     ) {
-        parent::__construct($status, $message);
+        parent::__construct($status, $message, null, $headers);
     }
 }

--- a/packages/payment/src/Contracts/PaymentDriver.php
+++ b/packages/payment/src/Contracts/PaymentDriver.php
@@ -36,8 +36,6 @@ interface PaymentDriver
     /**
      * Initiate a payment session with the provider.
      *
-     * Returns the data needed by the frontend (client_secret, order_id, etc.).
-     *
      * @param  array<string, mixed>  $context
      */
     public function initiatePayment(int $amount, string $currency, array $context = []): PaymentResult;
@@ -55,9 +53,7 @@ interface PaymentDriver
     public function capturePayment(string $reference, ?int $amount = null): PaymentResult;
 
     /**
-     * Refund a captured payment (full or partial). A caller-supplied
-     * `idempotency_key` in the context must make a retried refund collapse
-     * into a single refund at the gateway.
+     * Refund a captured payment (full or partial).
      *
      * @param  array<string, mixed>  $context
      */
@@ -74,11 +70,7 @@ interface PaymentDriver
     public function retrievePayment(string $reference): PaymentResult;
 
     /**
-     * Process an incoming webhook event from the provider. The reference is
-     * the payment reference the order was initiated with, and the event id is
-     * what makes a redelivery collapse. A refund event carries the amount of
-     * that refund alone, never a cumulative total, and its provider refund id
-     * under `data['refund_id']`.
+     * Process an incoming webhook event from the provider.
      *
      * @param  array<string, mixed>  $payload
      * @param  array<string, mixed>  $headers

--- a/packages/stripe/src/StripeDriver.php
+++ b/packages/stripe/src/StripeDriver.php
@@ -211,7 +211,7 @@ final class StripeDriver extends Driver
             $intent = $this->getClient()->paymentIntents->retrieve($reference);
 
             return new PaymentResult(
-                success: ! in_array($intent->status, ['canceled', 'requires_payment_method'], true),
+                success: $intent->status !== 'canceled',
                 status: $this->mapIntentStatus($intent->status),
                 reference: $intent->id,
                 clientSecret: $intent->client_secret,

--- a/tests/Api/Feature/AuthEndpointsTest.php
+++ b/tests/Api/Feature/AuthEndpointsTest.php
@@ -63,6 +63,43 @@ it('logs a customer in and rejects invalid credentials', function (): void {
     ])->assertUnprocessable();
 });
 
+it('throttles failed logins per email, even with the right password afterwards', function (): void {
+    User::factory()->create(['email' => 'john@example.com', 'password' => Hash::make('correct-password')]);
+    User::factory()->create(['email' => 'jane@example.com', 'password' => Hash::make('correct-password')]);
+
+    $attempts = (int) config('shopper.http.login_failures');
+
+    for ($attempt = 0; $attempt < $attempts; $attempt++) {
+        $this->postJson('/store/auth/login', ['email' => 'Jöhn@Example.com', 'password' => 'wrong'])
+            ->assertUnprocessable()
+            ->assertJsonPath('errors.0.code', 'credentials_invalid');
+    }
+
+    $detail = $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'correct-password'])
+        ->assertStatus(429)
+        ->assertJsonPath('errors.0.code', 'rate_limited')
+        ->assertHeader('Retry-After')
+        ->json('errors.0.detail');
+
+    expect($detail)->toStartWith('Too many login attempts');
+
+    $this->postJson('/store/auth/login', ['email' => 'jane@example.com', 'password' => 'correct-password'])->assertOk();
+});
+
+it('clears the failed login count on a successful login', function (): void {
+    User::factory()->create(['email' => 'john@example.com', 'password' => Hash::make('correct-password')]);
+
+    $attempts = (int) config('shopper.http.login_failures');
+
+    for ($round = 0; $round < 2; $round++) {
+        for ($attempt = 1; $attempt < $attempts; $attempt++) {
+            $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'wrong'])->assertUnprocessable();
+        }
+
+        $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'correct-password'])->assertOk();
+    }
+});
+
 it('revokes the current token on logout', function (): void {
     User::factory()->create([
         'email' => 'leaving@example.com',

--- a/tests/Api/Feature/CheckoutEndpointsTest.php
+++ b/tests/Api/Feature/CheckoutEndpointsTest.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Exceptions;
+use Illuminate\Support\Sleep;
 use Laravel\Sanctum\Sanctum;
 use Shopper\Cart\Models\Cart;
 use Shopper\Core\Enum\AddressType;
@@ -20,6 +23,7 @@ use Shopper\Core\Models\PaymentMethod;
 use Shopper\Core\Models\Product;
 use Shopper\Core\Models\Zone;
 use Shopper\Payment\Enum\TransactionType;
+use Shopper\Payment\Exceptions\PaymentException;
 use Shopper\Payment\Facades\Payment;
 use Shopper\Payment\Models\PaymentTransaction;
 use Tests\Api\Stubs\FakePaymentDriver;
@@ -265,6 +269,118 @@ it('requires a payment method before opening a session', function (): void {
     $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")
         ->assertUnprocessable()
         ->assertJsonPath('errors.0.code', 'payment_method_required');
+});
+
+it('keeps the previous session when the provider refuses to open a new one and replaces it on the next attempt', function (): void {
+    Exceptions::fake();
+    $driver = new FakePaymentDriver;
+    Payment::extend('fake', fn (): FakePaymentDriver => $driver);
+
+    $method = PaymentMethod::factory()->create(['title' => 'Card', 'is_enabled' => true, 'driver' => 'fake']);
+    $method->zones()->attach($this->zone);
+
+    $this->cart->update(['payment_method_id' => $method->id]);
+
+    $url = "/store/carts/{$this->cart->public_id}/payment-session";
+
+    $this->postJson($url)->assertCreated()->assertJsonPath('data.id', 'fake_intent_1');
+
+    $this->cart->lines()->first()->update(['quantity' => 2]);
+    $driver->throwOnInitiate = true;
+
+    $this->postJson($url)
+        ->assertStatus(503)
+        ->assertJsonPath('errors.0.code', 'payment_provider_unavailable');
+
+    Exceptions::assertReported(PaymentException::class);
+
+    expect($driver->cancellations)->toBe(0)
+        ->and($this->cart->refresh()->payment_session['reference'])->toBe('fake_intent_1');
+
+    $driver->throwOnInitiate = false;
+
+    $this->postJson($url)->assertCreated()->assertJsonPath('data.id', 'fake_intent_3');
+
+    expect($driver->cancellations)->toBe(1)
+        ->and($driver->lastCancelledReference)->toBe('fake_intent_1')
+        ->and(array_unique($driver->idempotencyKeys))->toHaveCount(3)
+        ->and($this->cart->refresh()->payment_session['reference'])->toBe('fake_intent_3');
+});
+
+it('answers 409 while another request is opening the payment session', function (): void {
+    Sleep::fake(syncWithCarbon: true);
+
+    $this->cart->update(['payment_method_id' => $this->paymentMethod->id]);
+
+    Cache::lock("cart:payment-session:{$this->cart->public_id}", 30)->get();
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")
+        ->assertConflict()
+        ->assertJsonPath('errors.0.code', 'payment_session_in_progress')
+        ->assertHeader('Retry-After');
+});
+
+it('drops the payment session and cancels its intent when the payment method changes', function (): void {
+    $driver = new FakePaymentDriver;
+    Payment::extend('fake', fn (): FakePaymentDriver => $driver);
+
+    $method = PaymentMethod::factory()->create(['title' => 'Card', 'is_enabled' => true, 'driver' => 'fake']);
+    $method->zones()->attach($this->zone);
+
+    $this->cart->update(['payment_method_id' => $method->id]);
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")->assertCreated();
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/payment-method", [
+        'payment_method_id' => (string) $this->paymentMethod->public_id,
+    ])->assertOk();
+
+    expect($this->cart->refresh()->payment_session)->toBeNull()
+        ->and($driver->lastCancelledReference)->toBe('fake_intent_1');
+});
+
+it('refuses to complete a cart paid through a provider without a payment session', function (): void {
+    Payment::extend('fake', fn (): FakePaymentDriver => new FakePaymentDriver);
+
+    $method = PaymentMethod::factory()->create(['title' => 'Card', 'is_enabled' => true, 'driver' => 'fake']);
+    $method->zones()->attach($this->zone);
+
+    readyCart($this->cart, $this->option, $method);
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/complete")
+        ->assertUnprocessable()
+        ->assertJsonPath('errors.0.code', 'payment_session_required');
+});
+
+it('answers 503 and reports it when the driver of the selected payment method is not configured', function (): void {
+    Exceptions::fake();
+    Payment::extend('fake', fn (): FakePaymentDriver => new FakePaymentDriver(configured: false));
+
+    $method = PaymentMethod::factory()->create(['title' => 'Card', 'is_enabled' => true, 'driver' => 'fake']);
+    $method->zones()->attach($this->zone);
+
+    $this->cart->update(['payment_method_id' => $method->id]);
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")
+        ->assertStatus(503)
+        ->assertJsonPath('errors.0.code', 'payment_method_not_configured');
+
+    Exceptions::assertReported(PaymentException::class);
+});
+
+it('answers 503 when the driver of the selected payment method is not registered', function (): void {
+    Exceptions::fake();
+
+    $method = PaymentMethod::factory()->create(['title' => 'Card', 'is_enabled' => true, 'driver' => 'ghost']);
+    $method->zones()->attach($this->zone);
+
+    $this->cart->update(['payment_method_id' => $method->id]);
+
+    $this->postJson("/store/carts/{$this->cart->public_id}/payment-session")
+        ->assertStatus(503)
+        ->assertJsonPath('errors.0.code', 'payment_method_not_configured');
+
+    Exceptions::assertReported(PaymentException::class);
 });
 
 it('completes the cart into an order', function (): void {

--- a/tests/Api/Feature/ErrorContractTest.php
+++ b/tests/Api/Feature/ErrorContractTest.php
@@ -70,7 +70,7 @@ it('keeps the rate limit headers on a throttled request', function (): void {
     $attempts = (int) config('shopper.http.rate_limiters.shopper-api-auth');
 
     for ($attempt = 0; $attempt < $attempts; $attempt++) {
-        $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'wrong'])->assertUnprocessable();
+        $this->postJson('/store/auth/login', ['email' => "john{$attempt}@example.com", 'password' => 'wrong'])->assertUnprocessable();
     }
 
     $this->postJson('/store/auth/login', ['email' => 'john@example.com', 'password' => 'wrong'])

--- a/tests/Api/Stubs/FakePaymentDriver.php
+++ b/tests/Api/Stubs/FakePaymentDriver.php
@@ -9,12 +9,15 @@ use Shopper\Payment\DataTransferObjects\PaymentResult;
 use Shopper\Payment\DataTransferObjects\WebhookResult;
 use Shopper\Payment\Drivers\Driver;
 use Shopper\Payment\Enum\WebhookAction;
+use Shopper\Payment\Exceptions\PaymentException;
 
 final class FakePaymentDriver extends Driver
 {
     public bool $failRetrieve = false;
 
     public bool $throwOnRetrieve = false;
+
+    public bool $throwOnInitiate = false;
 
     public ?string $retrievedStatus = null;
 
@@ -59,6 +62,10 @@ final class FakePaymentDriver extends Driver
         $this->lastAmount = $amount;
         $this->lastContext = $context;
         $this->idempotencyKeys[] = (string) ($context['idempotency_key'] ?? '');
+
+        if ($this->throwOnInitiate) {
+            throw PaymentException::apiError($this->code(), 'Provider down.');
+        }
 
         return new PaymentResult(
             success: true,

--- a/tests/Stripe/StripeDriverTest.php
+++ b/tests/Stripe/StripeDriverTest.php
@@ -580,7 +580,7 @@ describe(StripeDriver::class, function (): void {
                 ->and($result->status)->toBe('canceled');
         });
 
-        it('returns not successful for `requires_payment_method` status', function (): void {
+        it('keeps a `requires_payment_method` intent resumable', function (): void {
             $driver = createDriver();
             $mocks = injectMockClient($driver);
 
@@ -598,7 +598,7 @@ describe(StripeDriver::class, function (): void {
 
             $result = $driver->retrievePayment('pi_test_123');
 
-            expect($result->success)->toBeFalse()
+            expect($result->success)->toBeTrue()
                 ->and($result->status)->toBe('pending');
         });
 


### PR DESCRIPTION
## Summary

Two hardening points on the store API found while wiring the Next.js storefront: the payment session endpoint answered server-side failures as customer mistakes and let concurrent calls open two live intents, and the auth rate limit was keyed by IP alone, which a server-side storefront collapses into one address for every visitor. The review of the first point surfaced three older gaps in the session lifecycle, fixed here as well.

### Payment session

- A `PaymentException` thrown by `initiatePayment` (provider 5xx, rejected key, network failure) surfaced as a bare 500 `server_error`. It is now reported and answered as a 503 with the new `payment_provider_unavailable` code and a `Retry-After` header, so a storefront can offer a retry instead of a dead end.
- A payment method whose driver lost its configuration answered a 422 `payment_method_not_configured` with a pointer on `payment_method`, which storefronts render as a field error under the method picker. The method listing already hides unconfigured drivers, so reaching this branch is a store misconfiguration: it is now reported to the merchant and answered as a 503 with the same code, without a pointer. The guard runs through `PaymentManager::isConfigured()` before the driver is resolved, so a method left enabled after its driver addon was removed gets the same 503 instead of a 500. The message tells the customer to choose another method.
- The idempotency key is unique per attempt (`cart_{cart}_{ulid}`) instead of a version counter persisted with the session. Stripe saves the outcome of a key for 24 hours, errors included, and refuses the key with other parameters. With the counter, a retry after a provider error replayed the saved error, a cart edited after that error hit an idempotency rejection, and a currency change or a merge reset the counter to `v1`, reusing a key already spent on the same cart. The trade-off is documented on `openSession`: a response lost after the provider opened the intent leaves that intent unconfirmed at the provider, which collects nothing.
- Session creation is serialized per cart with a cache lock spanning the provider round trip. The deterministic key used to make the provider collapse two concurrent calls by accident; with a key per attempt, two double-submitted calls would each open a live intent while the cart remembered only one, and a customer could confirm the one no order records. The second call now waits up to three seconds and resumes what the first opened. A lock still held after that answers 409 `payment_session_in_progress` with `Retry-After`, reported so contention shows up in telemetry. The total, the completed state and the stored session are all read under the lock.
- The new intent is stored before the previous one is cancelled, so the cart never points at nothing: a failed initiation leaves the previous session in place, where a completion still checks its amount.
- `StripeDriver::retrievePayment()` reported `requires_payment_method`, the state of every intent the customer has not confirmed yet, as not successful, so a stored session was never resumed with Stripe: every call cancelled the intent the browser was holding and opened another one. Only `canceled` is terminal now.
- Changing the payment method drops the session and cancels its intent, the way a currency change already did, so an order never journals the reference of a method the customer abandoned.
- Completion reloads the cart instance it was given under `lockForUpdate` instead of fetching a second copy, so the session it checks and journals is the one on the locked row, not a snapshot taken before the transaction.
- A cart whose payment method collects through a provider refuses to complete without a payment session, with the new 422 `payment_session_required`; the manual driver keeps completing without one.

### Auth rate limit

- `POST /store/auth/login` counts failed attempts per email and origin, the key Laravel's own login throttling uses, transliterated and lowercased so an accented or capitalised variant of the address counts against the same bucket. A failure hits the count, a success clears it, and the request after `shopper.http.login_failures` failures within a minute (five by default) dispatches Laravel's `Lockout` event and answers 429 `rate_limited` with the `auth.throttle` message and a `Retry-After` header, even with the right password. An attacker cannot lock a customer out from another address. Register keeps the per-origin limit only, and forgot-password is already throttled per user by the password broker.
- The rate limiter config states what a server-side storefront must do so the per-origin limiters (`shopper-api`, `shopper-api-auth`, `shopper-api-checkout`) and the login key see one visitor and not one server: forward the visitor IP in `X-Forwarded-For` and trust the storefront with `trustProxies()` in `bootstrap/app.php`. `shopper:install` prints the same line in its next steps. The SDK already accepts per-request headers, so a kit can forward the IP without an SDK change.

## Upgrade notes

- `payment_method_not_configured` moves from a 422 with `source.pointer = /data/attributes/payment_method` to a 503 without a pointer. A storefront branching on that code must treat it as a service error, not as a field error.
- New error codes on the payment session endpoint: `payment_provider_unavailable` (503, retry after `Retry-After`), `payment_session_in_progress` (409, another request is opening the session, retry after `Retry-After`). New code on completion: `payment_session_required` (422) when the method collects through a provider and no session was opened.
- `data.idempotency_key` in the payment session response is now `cart_{cart}_{ulid}` instead of `cart_{cart}_v{n}`. Treat it as an opaque string.
- The `version` key of `carts.payment_session` is gone. Nothing in the core read it besides the session action; a host reading it must switch to the reference.
- The payment session endpoint takes a cache lock per cart, so the default cache store must support locks and be shared by every app server: `redis`, `database`, `memcached` or `dynamodb`. `file` and `array` accept the lock but serialize nothing across servers or processes, and a custom store must implement `LockProvider`.
- `PaymentDriver::retrievePayment()` must answer `success: false` only once the payment can no longer be confirmed. A third-party driver reporting an unconfirmed intent as unsuccessful is never resumed.
- `CreateOrderFromCartAction::execute()` now reloads the cart instance it receives under lock instead of fetching a second one, so callbacks and callers see the locked row.
- After `shopper.http.login_failures` failed logins for one email from one origin within a minute, the login endpoint answers 429 `rate_limited` instead of 422 `credentials_invalid`. A storefront that only handled 200 and 422 on login must handle the 429 and its `Retry-After` header.
- A published `config/shopper/http.php` keeps working without the new key: the controller falls back to five failures. Add `'login_failures' => 5` to tune it.
- A storefront calling from its own server must forward the visitor IP in `X-Forwarded-For` and be trusted in the host's `bootstrap/app.php` with `->trustProxies(at: [...])`, listing the storefront addresses. Never trust `*` on an API reachable from the public internet: a forged header would grant a fresh quota per request.
- The forgot-password endpoint relies on the host's `auth.passwords.users.throttle` for its per-account limit. Laravel's default is 60 seconds; 0 disables it.
