### PR TITLE
fix(api): carry product options inline so listings keep each product's values

### DIFF
--- a/packages/api/config/api.php
+++ b/packages/api/config/api.php
@@ -107,7 +107,7 @@ return [
         ],
         'attribute' => [
             'filters' => ['name' => 'partial'],
-            'sorts' => ['name', 'position'],
+            'sorts' => ['name'],
             'includes' => [],
         ],
         'tag' => [

--- a/packages/api/src/Concerns/RespondsWithCart.php
+++ b/packages/api/src/Concerns/RespondsWithCart.php
@@ -136,7 +136,7 @@ trait RespondsWithCart
         $variant = resolve(ProductVariantContract::class);
 
         $productLoads = $this->serializedLoads($product);
-        $variantLoads = $this->serializedLoads($variant);
+        $variantLoads = [...$this->serializedLoads($variant), 'values.attribute'];
 
         if ($includes->contains('lines.purchasable.product')) {
             $variantLoads = [...$variantLoads, ...array_map(fn (string $load): string => 'product.'.$load, $productLoads)];

--- a/packages/api/src/Http/Includes/ScopedOptions.php
+++ b/packages/api/src/Http/Includes/ScopedOptions.php
@@ -19,7 +19,9 @@ final class ScopedOptions implements IncludeInterface
     {
         $query->with([$include => function (Relation $options): void {
             $options->getQuery()
-                ->with('values')
+                ->scopes(['enabled'])
+                ->orderBy(shopper_table('attribute_product').'.id')
+                ->with(['values' => fn (Relation $values): Relation => $values->orderBy('position')->orderBy('id')])
                 ->afterQuery(fn (Collection $rows): Collection => $this->scopeToUsedValues($rows));
         }]);
     }
@@ -43,6 +45,12 @@ final class ScopedOptions implements IncludeInterface
                         $value->swatch_url = $swatches[$productId][$value->id] ?? null;
                     })
                     ->values());
+
+                $option->custom_value = $productRows
+                    ->where('id', $option->id)
+                    ->pluck('pivot.attribute_custom_value')
+                    ->filter()
+                    ->first();
 
                 $kept[spl_object_id($option)] = true;
             }

--- a/packages/api/src/Http/Resources/AttributeResource.php
+++ b/packages/api/src/Http/Resources/AttributeResource.php
@@ -30,7 +30,6 @@ class AttributeResource extends JsonApiResource
                 'key' => $value->key,
                 'value' => $value->value,
                 'position' => $value->position,
-                'swatch_url' => $value->swatch_url ?? null,
             ])->values()->all(),
         ];
     }

--- a/packages/api/src/Http/Resources/ProductResource.php
+++ b/packages/api/src/Http/Resources/ProductResource.php
@@ -7,6 +7,8 @@ namespace Shopper\Api\Http\Resources;
 use Illuminate\Http\Request;
 use Shopper\Api\Concerns\SerializesMedia;
 use Shopper\Api\Concerns\SerializesPrices;
+use Shopper\Core\Models\Attribute;
+use Shopper\Core\Models\AttributeValue;
 use Shopper\Core\Models\Product;
 
 /**
@@ -45,6 +47,7 @@ class ProductResource extends JsonApiResource
             'thumbnail' => $this->thumbnailPayload(withFallback: true),
             ...($this->isVirtual() ? ['files' => $this->filesPayload()] : []),
             ...$this->ratingPayload(),
+            ...$this->optionsPayload(),
             'created_at' => $this->created_at->toIso8601String(),
             'updated_at' => $this->updated_at->toIso8601String(),
         ];
@@ -62,10 +65,6 @@ class ProductResource extends JsonApiResource
 
         if ($this->canUseVariants()) {
             $relationships['variants'] = ProductVariantResource::class;
-        }
-
-        if ($this->canUseAttributes()) {
-            $relationships['options'] = AttributeResource::class;
         }
 
         return $relationships;
@@ -124,6 +123,39 @@ class ProductResource extends JsonApiResource
         return [
             'rating' => $average !== null ? round((float) $average, 1) : null,
             'reviews_count' => (int) $raw['reviews_count'],
+        ];
+    }
+
+    /**
+     * @return array<string, array<int, array<string, mixed>>>
+     */
+    private function optionsPayload(): array
+    {
+        if (! $this->canUseAttributes() || ! $this->resource->relationLoaded('options')) {
+            return [];
+        }
+
+        return [
+            'options' => $this->options
+                ->map(fn (Attribute $option): array => [
+                    'name' => $option->name,
+                    'slug' => $option->slug,
+                    'description' => $option->description,
+                    'type' => $option->type->value,
+                    'icon' => $option->icon,
+                    'custom_value' => $option->custom_value ?? null,
+                    'values' => $option->values
+                        ->map(fn (AttributeValue $value): array => [
+                            'key' => $value->key,
+                            'value' => $value->value,
+                            'position' => $value->position,
+                            'swatch_url' => $value->swatch_url ?? null,
+                        ])
+                        ->values()
+                        ->all(),
+                ])
+                ->values()
+                ->all(),
         ];
     }
 

--- a/packages/core/src/Models/Attribute.php
+++ b/packages/core/src/Models/Attribute.php
@@ -33,6 +33,7 @@ use Shopper\Core\Models\Traits\HasSlug;
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
  * @property-read \Illuminate\Database\Eloquent\Collection<int, AttributeValue> $values
+ * @property ?string $custom_value
  */
 class Attribute extends Model implements AttributeContract
 {

--- a/packages/core/src/Models/AttributeValue.php
+++ b/packages/core/src/Models/AttributeValue.php
@@ -20,7 +20,7 @@ use Shopper\Core\Models\Contracts\AttributeValue as AttributeValueContract;
  * @property-read int $attribute_id
  * @property-read Attribute $attribute
  * @property-read Collection<int, ProductVariant> $variants
- * @property ?string $swatch_url Transient per-product swatch image URL, set by the API when serializing a product's options.
+ * @property ?string $swatch_url
  */
 class AttributeValue extends Model implements AttributeValueContract
 {

--- a/packages/types/src/attribute.ts
+++ b/packages/types/src/attribute.ts
@@ -48,13 +48,6 @@ export interface AttributeValue {
   key: string
   /** The position/order. */
   position: number
-  /**
-   * Per-product swatch image URL for this value, shown instead of (or alongside)
-   * the hex `key`. Present on a product's `options` include; null when the value
-   * has no image for that product. The same value can carry a different image
-   * per product.
-   */
-  swatch_url?: string | null
   /** The attribute ID this value belongs to (admin contexts only). */
   attribute_id?: ResourceId
   /** The attribute this value belongs to. */

--- a/packages/types/src/product.ts
+++ b/packages/types/src/product.ts
@@ -1,4 +1,4 @@
-import type { Attribute } from './attribute'
+import type { FieldType } from './attribute'
 import type { Brand } from './brand'
 import type { Category } from './category'
 import type { Channel } from './channel'
@@ -73,8 +73,8 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   channels?: Channel[]
   /** The categories of the product. */
   categories?: Category[]
-  /** The options/attributes of the product. */
-  options?: Attribute[]
+  /** The options of the product, present with the `options` include. */
+  options?: ProductOption[]
   /** The collections of the product. */
   collections?: Collection[]
   /** The tags of the product. */
@@ -99,4 +99,34 @@ export interface Product extends Entity, SEOFields, ShippingFields {
   prices?: Price[]
   /** The min/max price aggregate in the resolved currency. Null when the product has no price in that currency. */
   price_range?: PriceRange | null
+}
+
+/** An option of a product, with the values that product uses. */
+export interface ProductOption {
+  /** The name of the attribute. */
+  name: string
+  /** The slug of the attribute. */
+  slug: string
+  /** The description of the attribute. */
+  description: string | null
+  /** The type of the attribute field. */
+  type: FieldType
+  /** The icon of the attribute. */
+  icon: string | null
+  /** The free text of a text type option. */
+  custom_value: string | null
+  /** The values this product uses. */
+  values: ProductOptionValue[]
+}
+
+/** A value of a product option. */
+export interface ProductOptionValue {
+  /** The display value. */
+  value: string
+  /** The key identifier (used as the facet filter value). */
+  key: string
+  /** The position/order. */
+  position: number
+  /** The swatch image URL for this product and value. */
+  swatch_url: string | null
 }

--- a/tests/Api/Feature/CartEndpointsTest.php
+++ b/tests/Api/Feature/CartEndpointsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Testing\TestResponse;
 use Laravel\Sanctum\Sanctum;
@@ -14,6 +15,8 @@ use Shopper\Core\Enum\DiscountEligibility;
 use Shopper\Core\Enum\DiscountRequirement;
 use Shopper\Core\Enum\DiscountType;
 use Shopper\Core\Enum\ProductType;
+use Shopper\Core\Models\Attribute;
+use Shopper\Core\Models\AttributeValue;
 use Shopper\Core\Models\Category;
 use Shopper\Core\Models\Country;
 use Shopper\Core\Models\Currency;
@@ -202,6 +205,39 @@ it('adds a variant to the cart', function (): void {
     expect($line['attributes']['unit_price_amount'])->toBe(3000)
         ->and($line['attributes']['purchasable_type'])->toBe('variant')
         ->and($variants->sole()['id'])->toBe($variant->public_id);
+});
+
+it('carries the option values of a variant line, in a constant number of queries', function (): void {
+    $variant = ProductVariant::factory()->create(['product_id' => $this->product->id, 'name' => 'Tee 1234']);
+    $variant->prices()->create(['amount' => 3000, 'currency_id' => $this->currency->id]);
+    $variant->mutateStock($this->inventory->id, 20);
+
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $size = Attribute::factory()->create(['name' => 'Size']);
+    $black = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Black', 'key' => 'black']);
+    $medium = AttributeValue::factory()->create(['attribute_id' => $size->id, 'value' => 'M', 'key' => 'm']);
+    $variant->values()->attach([$black->id, $medium->id]);
+
+    $cartId = $this->postJson('/store/carts')->json('data.id');
+
+    DB::enableQueryLog();
+    DB::flushQueryLog();
+
+    $response = $this->postJson("/store/carts/{$cartId}/lines?include=lines.purchasable", [
+        'purchasable_type' => 'variant',
+        'purchasable_id' => $variant->public_id,
+    ])->assertOk();
+
+    $attributeReads = collect(DB::getQueryLog())
+        ->filter(fn (array $query): bool => str_contains((string) $query['query'], shopper_table('attributes')))
+        ->count();
+
+    $values = collect(collect($response->json('included'))->where('type', 'variants')->sole()['attributes']['values']);
+
+    expect($values->pluck('value')->all())->toEqualCanonicalizing(['Black', 'M'])
+        ->and($values->pluck('attribute')->all())->toEqualCanonicalizing(['Color', 'Size'])
+        ->and($values->firstWhere('value', 'Black')['attribute_slug'])->toBe($color->slug)
+        ->and($attributeReads)->toBe(1);
 });
 
 it('rejects purchasables a storefront cannot sell', function (): void {

--- a/tests/Api/Feature/ProductCatalogTest.php
+++ b/tests/Api/Feature/ProductCatalogTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
+use Shopper\Core\Enum\FieldType;
 use Shopper\Core\Enum\ProductType;
 use Shopper\Core\Models\Attribute;
 use Shopper\Core\Models\AttributeValue;
@@ -272,7 +273,7 @@ it('exposes variant option values for option matching', function (): void {
         ]);
 });
 
-it('serializes product options as a deduplicated array scoped to the used values', function (): void {
+it('serializes product options inline, scoped to the values the product uses', function (): void {
     $product = publishedProduct(['name' => 'Phone', 'type' => ProductType::Standard]);
     $color = Attribute::factory()->create(['name' => 'Color']);
     $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
@@ -283,13 +284,96 @@ it('serializes product options as a deduplicated array scoped to the used values
     $product->options()->attach($color->id, ['attribute_value_id' => $blue->id]);
 
     $response = $this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk();
-    $optionsData = $response->json('data.relationships.options.data');
-    $colorOption = collect($response->json('included'))->firstWhere('type', 'attributes');
-    $values = collect($colorOption['attributes']['values'])->pluck('value');
+    $options = $response->json('data.attributes.options');
+    $values = collect($options[0]['values'])->pluck('value');
 
-    expect($optionsData)->toBeArray()->toHaveCount(1)
-        ->and(array_is_list($optionsData))->toBeTrue()
-        ->and($values)->toContain('Red', 'Blue')->not->toContain('Green');
+    expect($options)->toBeArray()->toHaveCount(1)
+        ->and(array_is_list($options))->toBeTrue()
+        ->and($options[0])->toMatchArray(['name' => 'Color', 'slug' => $color->slug])
+        ->and($values)->toContain('Red', 'Blue')->not->toContain('Green')
+        ->and($response->json('data.relationships.options'))->toBeNull()
+        ->and($response->json('included'))->toBeNull();
+});
+
+it('keeps the option values of each product apart on the listing', function (): void {
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
+    $blue = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Blue', 'key' => 'blue']);
+    $green = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Green', 'key' => 'green']);
+
+    $phone = publishedProduct(['name' => 'OptPhone']);
+    $phone->options()->attach($color->id, ['attribute_value_id' => $red->id]);
+    $phone->options()->attach($color->id, ['attribute_value_id' => $blue->id]);
+
+    $tablet = publishedProduct(['name' => 'OptTablet']);
+    $tablet->options()->attach($color->id, ['attribute_value_id' => $green->id]);
+
+    $values = collect($this->getJson('/store/products?filter[name]=Opt&include=options')->assertOk()->json('data'))
+        ->keyBy('attributes.name')
+        ->map(fn (array $product): array => collect($product['attributes']['options'][0]['values'])->pluck('value')->all());
+
+    expect($values->get('OptPhone'))->toEqualCanonicalizing(['Red', 'Blue'])
+        ->and($values->get('OptTablet'))->toBe(['Green']);
+});
+
+it('never exposes an option the merchant disabled', function (): void {
+    $product = publishedProduct(['name' => 'Hoodie']);
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $size = Attribute::factory()->disabled()->create(['name' => 'Size']);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
+    $large = AttributeValue::factory()->create(['attribute_id' => $size->id, 'value' => 'Large', 'key' => 'large']);
+
+    $product->options()->attach($color->id, ['attribute_value_id' => $red->id]);
+    $product->options()->attach($size->id, ['attribute_value_id' => $large->id]);
+
+    $options = $this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk()->json('data.attributes.options');
+
+    expect($options)->toHaveCount(1)
+        ->and($options[0]['name'])->toBe('Color');
+});
+
+it('carries the free text of a text type option', function (): void {
+    $product = publishedProduct(['name' => 'Jacket']);
+    $material = Attribute::factory()->create(['name' => 'Material', 'type' => FieldType::Text]);
+
+    $product->options()->attach($material->id, ['attribute_custom_value' => 'Merino wool']);
+
+    $options = $this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk()->json('data.attributes.options');
+
+    expect($options)->toHaveCount(1)
+        ->and($options[0])->toMatchArray(['name' => 'Material', 'custom_value' => 'Merino wool'])
+        ->and($options[0]['values'])->toBe([]);
+});
+
+it('orders the options by attachment and their values by position', function (): void {
+    $product = publishedProduct(['name' => 'Tee']);
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $size = Attribute::factory()->create(['name' => 'Size']);
+    $blue = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Blue', 'key' => 'tee-blue', 'position' => 2]);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'tee-red', 'position' => 1]);
+    $large = AttributeValue::factory()->create(['attribute_id' => $size->id, 'value' => 'Large', 'key' => 'tee-large', 'position' => 1]);
+
+    $product->options()->attach($color->id, ['attribute_value_id' => $blue->id]);
+    $product->options()->attach($color->id, ['attribute_value_id' => $red->id]);
+    $product->options()->attach($size->id, ['attribute_value_id' => $large->id]);
+
+    $options = $this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk()->json('data.attributes.options');
+
+    expect(collect($options)->pluck('name')->all())->toBe(['Color', 'Size'])
+        ->and(collect($options[0]['values'])->pluck('value')->all())->toBe(['Red', 'Blue']);
+});
+
+it('leaves the options out until the client asks for them', function (): void {
+    $product = publishedProduct(['name' => 'Sweater']);
+    $color = Attribute::factory()->create(['name' => 'Color']);
+    $red = AttributeValue::factory()->create(['attribute_id' => $color->id, 'value' => 'Red', 'key' => 'red']);
+
+    $product->options()->attach($color->id, ['attribute_value_id' => $red->id]);
+
+    expect($this->getJson('/store/products/'.$product->slug)->assertOk()->json('data.attributes'))
+        ->not->toHaveKey('options')
+        ->and(collect($this->getJson('/store/products?filter[name]=Sweater')->assertOk()->json('data'))->first()['attributes'])
+        ->not->toHaveKey('options');
 });
 
 it('exposes a per-product swatch image url on option values when one is attached', function (): void {
@@ -313,9 +397,8 @@ it('exposes a per-product swatch image url on option values when one is attached
         ->usingFileName('red.png')
         ->toMediaCollection('swatch');
 
-    $colorOption = collect($this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk()->json('included'))
-        ->firstWhere('type', 'attributes');
-    $values = collect($colorOption['attributes']['values'])->keyBy('value');
+    $values = collect($this->getJson('/store/products/'.$product->slug.'?include=options')->assertOk()->json('data.attributes.options.0.values'))
+        ->keyBy('value');
 
     expect($values['Red']['swatch_url'])->toBeString()->toContain('red.png')
         ->and($values['Blue']['swatch_url'])->toBeNull();
@@ -378,7 +461,7 @@ it('shapes the payload by product type', function (): void {
         ->not->toHaveKeys(['stock', 'variants_stock', 'files']);
 });
 
-it('only exposes the variants and options relationships for capable product types', function (): void {
+it('only exposes the variants relationship and the options for capable product types', function (): void {
     publishedProduct(['name' => 'RelVariant', 'type' => ProductType::Variant]);
     publishedProduct(['name' => 'RelExternal', 'type' => ProductType::External, 'external_id' => 'ext-1']);
 
@@ -387,8 +470,9 @@ it('only exposes the variants and options relationships for capable product type
     )->keyBy('attributes.name');
 
     expect($products->get('RelVariant')['relationships'])->toHaveKey('variants')
+        ->and($products->get('RelVariant')['attributes'])->toHaveKey('options')
         ->and($products->get('RelExternal')['relationships'] ?? [])->not->toHaveKey('variants')
-        ->not->toHaveKey('options');
+        ->and($products->get('RelExternal')['attributes'])->not->toHaveKey('options');
 });
 
 it('paginates with page[size] and page[number]', function (): void {

--- a/tests/Api/Feature/ProductChannelScopingTest.php
+++ b/tests/Api/Feature/ProductChannelScopingTest.php
@@ -126,7 +126,7 @@ it('scopes the products included through a collection to the same channel', func
     expect(includedProductNames($this, '/store/collections/summer?include=products', ['X-Shopper-Channel' => 'webstore']))
         ->toBe(['On Webstore'])
         ->and(includedProductNames($this, '/store/collections/summer?include=products'))
-        ->toBe(['On Webstore', 'Unattached']);
+        ->toEqualCanonicalizing(['On Webstore', 'Unattached']);
 });
 
 it('scopes the related products of a product to the same channel', function (): void {


### PR DESCRIPTION
## Summary

`GET /store/products?include=options` returned the wrong option values for every product after the first one sharing an attribute. `ScopedOptions` builds one attribute instance per product, with the values that product uses and its per-product swatch URLs, but `ProductResource` exposed them as JSON:API `attributes` resources identified by the attribute id. The compound document deduplicates `included` by `type:id`, so the first product's values won and every other product pointed at them. The show endpoint never hit it, one product per document.

Scoped values and swatches belong to the product and attribute pair, not to the attribute, so they cannot live in a resource identified by the attribute alone. They now ride inline on the product, the way `rating`, `price_range` and `variants.values` already do.

- `ProductResource` drops the `options` relationship and carries `options` in its attributes when the `options` include is requested and the product type accepts attributes. Each entry keeps the fields the `attributes` resource had: `name`, `slug`, `description`, `type`, `icon` and `values` with `key`, `value`, `position` and `swatch_url`.
- The include stays declared under the same name, `ScopedOptions` keeps loading and scoping the relation, and `AttributeResource` keeps serving `/store/attributes`.
- A listing test with two products on the same attribute pins the fix: each product answers its own values.
- `@shopperlabs/shopper-types` types `Product.options` as `ProductOption[]`. The SDK needs no change: `flatten()` spreads attributes, so `product.options` stays an array on the entity.

## Upgrade notes

- A storefront reading `data.relationships.options` and the `attributes` entries of `included` on a product document must read `data.attributes.options` instead. The include name and the fields are unchanged.
- `Product.options` in `@shopperlabs/shopper-types` is now `ProductOption[]`, an inline object without an id, instead of `Attribute[]`. `filter[option]` matches on `values[].key`, and variant `values` carry `attribute_slug`, so nothing needed the id.
