### PR TITLE
feat(shipping): track UPS and FedEx shipments and advance the order from carrier scans

### DIFF
--- a/packages/shipping/config/shipping.php
+++ b/packages/shipping/config/shipping.php
@@ -108,6 +108,11 @@ return [
     | tracking are queued, and each job pulls the carrier timeline into
     | the shipment events. Carriers that push webhooks do not need it.
     |
+    | High volumes are better kept off the default queue, where they would
+    | sit in front of payment and order jobs. Name a queue below and run a
+    | worker for it. Carrier tokens live in the default cache store, so run
+    | a shared one when several nodes poll.
+    |
     */
 
     'tracking' => [

--- a/packages/shipping/src/Concerns/InteractsWithCarrierApi.php
+++ b/packages/shipping/src/Concerns/InteractsWithCarrierApi.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Shipping\Concerns;
+
+use Closure;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Shipping\DataTransferObjects\TrackingEvent;
+use Shopper\Shipping\Exceptions\ShippingException;
+
+trait InteractsWithCarrierApi
+{
+    /**
+     * @param  Closure(): array{0: string, 1: int}  $request
+     */
+    protected function cachedToken(string $key, Closure $request): string
+    {
+        $key = 'shopper.shipping.token.'.$key;
+        $token = $this->storedToken($key);
+
+        if ($token !== null) {
+            return $token;
+        }
+
+        $lock = Cache::lock($key.'.lock', 10);
+        $lock->block(5);
+
+        try {
+            return $this->storedToken($key) ?? $this->storeToken($key, $request);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * @return array{0: string, 1: int}
+     */
+    protected function readToken(Response $response): array
+    {
+        if ($response->failed()) {
+            throw ShippingException::apiError($this->code(), $this->carrierMessage($response));
+        }
+
+        $token = $response->json('access_token');
+
+        if (! is_string($token) || $token === '') {
+            throw ShippingException::invalidResponse($this->code());
+        }
+
+        return [$token, (int) $response->json('expires_in', 3600)];
+    }
+
+    /**
+     * @param  Collection<int, TrackingEvent>  $events
+     */
+    protected function highestStatus(Collection $events): ShipmentStatus
+    {
+        return $events
+            ->sortBy(fn (TrackingEvent $event): int => $event->occurredAt->getTimestamp())
+            ->reduce(
+                fn (ShipmentStatus $carry, TrackingEvent $event): ShipmentStatus => $event->status->rank() >= $carry->rank()
+                    ? $event->status
+                    : $carry,
+                ShipmentStatus::Pending,
+            );
+    }
+
+    protected function carrierMessage(Response $response): string
+    {
+        $paths = [
+            'response.errors.0.message',
+            'errors.0.message',
+            'output.alerts.0.message',
+            'error_description',
+            'error.message',
+        ];
+
+        foreach ($paths as $path) {
+            $message = $response->json($path);
+
+            if (is_string($message) && $message !== '') {
+                return $message;
+            }
+        }
+
+        return 'HTTP '.$response->status();
+    }
+
+    protected function carrierText(mixed $source, string $path): ?string
+    {
+        $value = data_get($source, $path);
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private function storedToken(string $key): ?string
+    {
+        $token = Cache::get($key);
+
+        return is_string($token) && $token !== '' ? $token : null;
+    }
+
+    /**
+     * @param  Closure(): array{0: string, 1: int}  $request
+     */
+    private function storeToken(string $key, Closure $request): string
+    {
+        [$token, $expiresIn] = $request();
+
+        Cache::put($key, $token, max(60, $expiresIn - 60));
+
+        return $token;
+    }
+}

--- a/packages/shipping/src/Drivers/FedExDriver.php
+++ b/packages/shipping/src/Drivers/FedExDriver.php
@@ -4,22 +4,32 @@ declare(strict_types=1);
 
 namespace Shopper\Shipping\Drivers;
 
+use Carbon\CarbonImmutable;
 use Exception;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
 use Mitrik\Shipping\ServiceProviders\Address\Address as MitrikAddress;
 use Mitrik\Shipping\ServiceProviders\Box\BoxCollection;
 use Mitrik\Shipping\ServiceProviders\Box\BoxMetric;
 use Mitrik\Shipping\ServiceProviders\ServiceFedEx\ServiceFedEx;
 use Mitrik\Shipping\ServiceProviders\ServiceFedEx\ServiceFedExCredentials;
+use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Shipping\Concerns\InteractsWithCarrierApi;
 use Shopper\Shipping\DataTransferObjects\Address;
 use Shopper\Shipping\DataTransferObjects\Package;
-use Shopper\Shipping\DataTransferObjects\Shipment;
 use Shopper\Shipping\DataTransferObjects\ShippingRate;
+use Shopper\Shipping\DataTransferObjects\TrackingEvent;
 use Shopper\Shipping\DataTransferObjects\TrackingInfo;
 use Shopper\Shipping\Exceptions\ShippingException;
+use Shopper\Shipping\Exceptions\TrackingNotFoundException;
+use Throwable;
 
 final class FedExDriver extends Driver
 {
+    use InteractsWithCarrierApi;
+
     private ?ServiceFedEx $client = null;
 
     public function __construct(
@@ -49,6 +59,16 @@ final class FedExDriver extends Driver
         return filled($this->clientId)
             && filled($this->clientSecret)
             && filled($this->accountNumber);
+    }
+
+    public function supportsLabels(): bool
+    {
+        return false;
+    }
+
+    public function supportsTracking(): bool
+    {
+        return true;
     }
 
     public function calculateRates(Address $from, Address $to, array $packages): Collection
@@ -86,31 +106,191 @@ final class FedExDriver extends Driver
         }
     }
 
-    public function createShipment(
-        Address $from,
-        Address $to,
-        array $packages,
-        string $serviceCode
-    ): Shipment {
-        if (! $this->isConfigured()) {
-            throw ShippingException::notConfigured('fedex');
-        }
-
-        throw ShippingException::notSupported('createShipment', 'fedex');
-    }
-
-    public function supportsTracking(): bool
-    {
-        return true;
-    }
-
     public function track(string $trackingNumber): TrackingInfo
     {
         if (! $this->isConfigured()) {
             throw ShippingException::notConfigured('fedex');
         }
 
-        throw ShippingException::notSupported('track', 'fedex');
+        try {
+            $response = $this->api()
+                ->withToken($this->accessToken())
+                ->post('/track/v1/trackingnumbers', [
+                    'includeDetailedScans' => true,
+                    'trackingInfo' => [
+                        ['trackingNumberInfo' => ['trackingNumber' => $trackingNumber]],
+                    ],
+                ]);
+        } catch (ConnectionException $e) {
+            throw ShippingException::apiError('fedex', $e->getMessage());
+        }
+
+        if ($response->failed()) {
+            throw ShippingException::apiError('fedex', $this->carrierMessage($response));
+        }
+
+        $result = $response->json('output.completeTrackResults.0.trackResults.0');
+
+        if (! is_array($result)) {
+            throw ShippingException::invalidResponse('fedex');
+        }
+
+        $this->failOnResultError($trackingNumber, $result);
+
+        return $this->toTrackingInfo($trackingNumber, $result);
+    }
+
+    private function api(): PendingRequest
+    {
+        return Http::baseUrl($this->sandbox ? 'https://apis-sandbox.fedex.com' : 'https://apis.fedex.com')
+            ->acceptJson()
+            ->timeout(15)
+            ->retry(3, 200, fn (Throwable $e): bool => $e instanceof ConnectionException, throw: false);
+    }
+
+    private function accessToken(): string
+    {
+        $key = 'fedex:'.sha1($this->clientId.'|'.($this->sandbox ? 'test' : 'live'));
+
+        return $this->cachedToken($key, fn (): array => $this->readToken(
+            $this->api()->asForm()->post('/oauth/token', [
+                'grant_type' => 'client_credentials',
+                'client_id' => $this->clientId,
+                'client_secret' => $this->clientSecret,
+            ])
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function failOnResultError(string $trackingNumber, array $result): void
+    {
+        $code = $this->carrierText($result, 'error.code');
+
+        if ($code === null) {
+            return;
+        }
+
+        if (str_contains($code, 'NOTFOUND')) {
+            throw TrackingNotFoundException::for('fedex', $trackingNumber);
+        }
+
+        throw ShippingException::apiError('fedex', $this->carrierText($result, 'error.message') ?? $code);
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function toTrackingInfo(string $trackingNumber, array $result): TrackingInfo
+    {
+        $events = collect(data_get($result, 'scanEvents', []))
+            ->map(fn (mixed $scan): ?TrackingEvent => is_array($scan) ? $this->toTrackingEvent($scan) : null)
+            ->filter()
+            ->values();
+
+        $delivered = $events->first(fn (TrackingEvent $event): bool => $event->status === ShipmentStatus::Delivered);
+
+        $deliveredAt = $this->carrierDate($result, 'ACTUAL_DELIVERY')
+            ?? ($delivered !== null ? CarbonImmutable::instance($delivered->occurredAt) : null);
+
+        if ($deliveredAt !== null && $delivered === null) {
+            $events->push(new TrackingEvent(
+                status: ShipmentStatus::Delivered,
+                description: $this->latestDescription($result),
+                occurredAt: $deliveredAt,
+                externalId: 'fedex:delivered:'.$trackingNumber,
+            ));
+        }
+
+        return new TrackingInfo(
+            trackingNumber: $trackingNumber,
+            status: $this->highestStatus($events),
+            statusDescription: $this->latestDescription($result),
+            estimatedDelivery: $this->carrierDate($result, 'ESTIMATED_DELIVERY'),
+            deliveredAt: $deliveredAt,
+            events: $events->all(),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $scan
+     */
+    private function toTrackingEvent(array $scan): ?TrackingEvent
+    {
+        $occurredAt = $this->instant(data_get($scan, 'date'));
+
+        if ($occurredAt === null) {
+            return null;
+        }
+
+        $type = $this->carrierText($scan, 'eventType') ?? '';
+
+        return new TrackingEvent(
+            status: $this->toStatus($this->carrierText($scan, 'derivedStatusCode') ?? $type),
+            description: $this->carrierText($scan, 'eventDescription') ?? $this->carrierText($scan, 'derivedStatus'),
+            occurredAt: $occurredAt,
+            location: $this->toLocation($scan),
+            externalId: 'fedex:'.$occurredAt->format('YmdHis').':'.$type,
+        );
+    }
+
+    private function toStatus(string $code): ShipmentStatus
+    {
+        return match ($code) {
+            'OC' => ShipmentStatus::Pending,
+            'PU' => ShipmentStatus::PickedUp,
+            'AR' => ShipmentStatus::AtSortingCenter,
+            'OD' => ShipmentStatus::OutForDelivery,
+            'DL' => ShipmentStatus::Delivered,
+            'DE', 'SE' => ShipmentStatus::DeliveryFailed,
+            'RS' => ShipmentStatus::Returned,
+            default => ShipmentStatus::InTransit,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $scan
+     */
+    private function toLocation(array $scan): ?string
+    {
+        return collect([
+            $this->carrierText($scan, 'scanLocation.city'),
+            $this->carrierText($scan, 'scanLocation.stateOrProvinceCode'),
+            $this->carrierText($scan, 'scanLocation.countryCode'),
+        ])->filter()->implode(', ') ?: null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function latestDescription(array $result): ?string
+    {
+        return $this->carrierText($result, 'latestStatusDetail.statusByLocale')
+            ?? $this->carrierText($result, 'latestStatusDetail.description');
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     */
+    private function carrierDate(array $result, string $type): ?CarbonImmutable
+    {
+        $entry = collect(data_get($result, 'dateAndTimes', []))->firstWhere('type', $type);
+
+        return $this->instant(data_get($entry, 'dateTime'));
+    }
+
+    private function instant(mixed $value): ?CarbonImmutable
+    {
+        if (! is_string($value) || $value === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value)->utc();
+        } catch (Exception) {
+            return null;
+        }
     }
 
     private function getClient(): ServiceFedEx

--- a/packages/shipping/src/Drivers/UpsDriver.php
+++ b/packages/shipping/src/Drivers/UpsDriver.php
@@ -4,22 +4,34 @@ declare(strict_types=1);
 
 namespace Shopper\Shipping\Drivers;
 
+use Carbon\CarbonImmutable;
 use Exception;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Mitrik\Shipping\ServiceProviders\Address\Address as MitrikAddress;
 use Mitrik\Shipping\ServiceProviders\Box\BoxCollection;
 use Mitrik\Shipping\ServiceProviders\Box\BoxMetric;
 use Mitrik\Shipping\ServiceProviders\ServiceUPS\ServiceUPS;
 use Mitrik\Shipping\ServiceProviders\ServiceUPS\ServiceUPSCredentials;
+use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Shipping\Concerns\InteractsWithCarrierApi;
 use Shopper\Shipping\DataTransferObjects\Address;
 use Shopper\Shipping\DataTransferObjects\Package;
-use Shopper\Shipping\DataTransferObjects\Shipment;
 use Shopper\Shipping\DataTransferObjects\ShippingRate;
+use Shopper\Shipping\DataTransferObjects\TrackingEvent;
 use Shopper\Shipping\DataTransferObjects\TrackingInfo;
 use Shopper\Shipping\Exceptions\ShippingException;
+use Shopper\Shipping\Exceptions\TrackingNotFoundException;
+use Throwable;
 
 final class UpsDriver extends Driver
 {
+    use InteractsWithCarrierApi;
+
     private ?ServiceUPS $client = null;
 
     public function __construct(
@@ -51,6 +63,16 @@ final class UpsDriver extends Driver
             && filled($this->clientSecret)
             && filled($this->userId)
             && filled($this->accountNumber);
+    }
+
+    public function supportsLabels(): bool
+    {
+        return false;
+    }
+
+    public function supportsTracking(): bool
+    {
+        return true;
     }
 
     public function calculateRates(Address $from, Address $to, array $packages): Collection
@@ -88,34 +110,229 @@ final class UpsDriver extends Driver
         }
     }
 
-    public function createShipment(
-        Address $from,
-        Address $to,
-        array $packages,
-        string $serviceCode
-    ): Shipment {
-        if (! $this->isConfigured()) {
-            throw ShippingException::notConfigured('ups');
-        }
-
-        // Implementation would use ServiceUPS->ship() method
-        // This is a placeholder for the full implementation
-        throw ShippingException::notSupported('createShipment', 'ups');
-    }
-
-    public function supportsTracking(): bool
-    {
-        return true;
-    }
-
     public function track(string $trackingNumber): TrackingInfo
     {
         if (! $this->isConfigured()) {
             throw ShippingException::notConfigured('ups');
         }
 
-        // Implementation would use UPS Tracking API
-        throw ShippingException::notSupported('track', 'ups');
+        try {
+            $response = $this->api()
+                ->withToken($this->accessToken())
+                ->withHeaders([
+                    'transId' => (string) Str::uuid()->getHex(),
+                    'transactionSrc' => 'shopper',
+                ])
+                ->get('/api/track/v1/details/'.rawurlencode($trackingNumber), [
+                    'locale' => 'en_US',
+                    'returnSignature' => 'false',
+                ]);
+        } catch (ConnectionException $e) {
+            throw ShippingException::apiError('ups', $e->getMessage());
+        }
+
+        if ($this->deniesTracking($response)) {
+            throw TrackingNotFoundException::for('ups', $trackingNumber);
+        }
+
+        if ($response->failed()) {
+            throw ShippingException::apiError('ups', $this->carrierMessage($response));
+        }
+
+        $package = $response->json('trackResponse.shipment.0.package.0');
+
+        if (! is_array($package)) {
+            throw ShippingException::invalidResponse('ups');
+        }
+
+        return $this->toTrackingInfo($trackingNumber, $package);
+    }
+
+    private function api(): PendingRequest
+    {
+        return Http::baseUrl($this->sandbox ? 'https://wwwcie.ups.com' : 'https://onlinetools.ups.com')
+            ->acceptJson()
+            ->timeout(15)
+            ->retry(3, 200, fn (Throwable $e): bool => $e instanceof ConnectionException, throw: false);
+    }
+
+    private function accessToken(): string
+    {
+        $key = 'ups:'.sha1($this->clientId.'|'.($this->sandbox ? 'test' : 'live'));
+
+        return $this->cachedToken($key, fn (): array => $this->readToken(
+            $this->api()
+                ->asForm()
+                ->withBasicAuth($this->clientId, $this->clientSecret)
+                ->post('/security/v1/oauth/token', ['grant_type' => 'client_credentials'])
+        ));
+    }
+
+    private function deniesTracking(Response $response): bool
+    {
+        return $response->notFound() && $this->carrierText($response->json(), 'response.errors.0.code') !== null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function toTrackingInfo(string $trackingNumber, array $package): TrackingInfo
+    {
+        $events = collect(data_get($package, 'activity', []))
+            ->map(fn (mixed $activity): ?TrackingEvent => is_array($activity) ? $this->toTrackingEvent($activity) : null)
+            ->filter()
+            ->values();
+
+        $deliveredAt = $this->deliveredAt($package);
+
+        if ($deliveredAt !== null) {
+            $events->push(new TrackingEvent(
+                status: ShipmentStatus::Delivered,
+                description: $this->carrierText($package, 'currentStatus.description'),
+                occurredAt: $deliveredAt,
+                externalId: 'ups:delivered:'.$trackingNumber,
+            ));
+        }
+
+        $current = $this->carrierText($package, 'currentStatus.type');
+
+        return new TrackingInfo(
+            trackingNumber: $trackingNumber,
+            status: match (true) {
+                $events->isNotEmpty() => $this->highestStatus($events),
+                $current !== null => $this->toStatus($current),
+                default => ShipmentStatus::Pending,
+            },
+            statusDescription: $this->carrierText($package, 'currentStatus.description'),
+            estimatedDelivery: $this->carrierDate($package, 'RDD') ?? $this->carrierDate($package, 'SDD'),
+            deliveredAt: $deliveredAt,
+            events: $events->all(),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $activity
+     */
+    private function toTrackingEvent(array $activity): ?TrackingEvent
+    {
+        $occurredAt = $this->instantOf($activity);
+
+        if ($occurredAt === null) {
+            return null;
+        }
+
+        $type = $this->carrierText($activity, 'status.type') ?? '';
+        $code = $this->carrierText($activity, 'status.code') ?? $type;
+
+        return new TrackingEvent(
+            status: $this->toStatus($type),
+            description: $this->carrierText($activity, 'status.description'),
+            occurredAt: $occurredAt,
+            location: $this->toLocation($activity),
+            externalId: 'ups:'.$occurredAt->format('YmdHis').':'.$code,
+        );
+    }
+
+    private function toStatus(string $type): ShipmentStatus
+    {
+        return match ($type) {
+            'M' => ShipmentStatus::Pending,
+            'P' => ShipmentStatus::PickedUp,
+            'D' => ShipmentStatus::OutForDelivery,
+            'X' => ShipmentStatus::DeliveryFailed,
+            default => ShipmentStatus::InTransit,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $activity
+     */
+    private function instantOf(array $activity): ?CarbonImmutable
+    {
+        $gmt = $this->stamp($activity, 'gmtDate', 'gmtTime');
+
+        if ($gmt !== null) {
+            return CarbonImmutable::createFromFormat('YmdHis', $gmt, 'UTC');
+        }
+
+        $local = $this->stamp($activity, 'date', 'time');
+        $offset = $this->carrierText($activity, 'gmtOffset');
+
+        if ($local === null || $offset === null) {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse(mb_substr($local, 0, 8).'T'.mb_substr($local, 8).$offset)->utc();
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $activity
+     */
+    private function stamp(array $activity, string $dateKey, string $timeKey): ?string
+    {
+        $stamp = preg_replace('/\D/', '', ($this->carrierText($activity, $dateKey) ?? '').($this->carrierText($activity, $timeKey) ?? ''));
+
+        return is_string($stamp) && mb_strlen($stamp) === 14 ? $stamp : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $activity
+     */
+    private function toLocation(array $activity): ?string
+    {
+        return collect([
+            $this->carrierText($activity, 'location.address.city'),
+            $this->carrierText($activity, 'location.address.stateProvince'),
+            $this->carrierText($activity, 'location.address.countryCode'),
+        ])->filter()->implode(', ') ?: null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function deliveredAt(array $package): ?CarbonImmutable
+    {
+        $date = $this->carrierDateString($package, 'DEL');
+
+        if ($date === null) {
+            return null;
+        }
+
+        return collect(data_get($package, 'activity', []))
+            ->map(fn (mixed $activity): ?CarbonImmutable => is_array($activity)
+                && $this->carrierText($activity, 'date') === $date
+                    ? $this->instantOf($activity)
+                    : null)
+            ->filter()
+            ->sort()
+            ->last();
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function carrierDate(array $package, string $type): ?CarbonImmutable
+    {
+        $date = $this->carrierDateString($package, $type);
+
+        return $date === null
+            ? null
+            : CarbonImmutable::createFromFormat('Ymd', $date, 'UTC')?->startOfDay();
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     */
+    private function carrierDateString(array $package, string $type): ?string
+    {
+        $entry = collect(data_get($package, 'deliveryDate', []))->firstWhere('type', $type);
+        $date = $this->carrierText($entry, 'date');
+
+        return $date !== null && CarbonImmutable::canBeCreatedFromFormat($date, 'Ymd') ? $date : null;
     }
 
     private function getClient(): ServiceUPS

--- a/packages/shipping/src/Exceptions/ShippingException.php
+++ b/packages/shipping/src/Exceptions/ShippingException.php
@@ -6,7 +6,7 @@ namespace Shopper\Shipping\Exceptions;
 
 use Exception;
 
-final class ShippingException extends Exception
+class ShippingException extends Exception
 {
     public static function notConfigured(string $driver): self
     {

--- a/packages/shipping/src/Exceptions/TrackingNotFoundException.php
+++ b/packages/shipping/src/Exceptions/TrackingNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopper\Shipping\Exceptions;
+
+final class TrackingNotFoundException extends ShippingException
+{
+    public static function for(string $driver, string $trackingNumber): self
+    {
+        return new self("The [{$driver}] carrier has no record of the tracking number [{$trackingNumber}].");
+    }
+}

--- a/packages/shipping/src/Jobs/SyncShipmentTrackingJob.php
+++ b/packages/shipping/src/Jobs/SyncShipmentTrackingJob.php
@@ -9,8 +9,11 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Log;
 use Shopper\Core\Models\OrderShipping;
 use Shopper\Shipping\Actions\ApplyTrackingInfoAction;
+use Shopper\Shipping\Exceptions\TrackingNotFoundException;
 use Shopper\Shipping\Facades\Shipping;
 
 final class SyncShipmentTrackingJob implements ShouldBeUnique, ShouldQueue
@@ -33,7 +36,9 @@ final class SyncShipmentTrackingJob implements ShouldBeUnique, ShouldQueue
      */
     public function backoff(): array
     {
-        return (array) config('shopper.shipping.tracking.backoff', [60, 300, 900]);
+        $backoff = Arr::wrap(config('shopper.shipping.tracking.backoff') ?? [60, 300, 900]);
+
+        return array_values(array_map('intval', $backoff));
     }
 
     public function tries(): int
@@ -57,6 +62,18 @@ final class SyncShipmentTrackingJob implements ShouldBeUnique, ShouldQueue
             return;
         }
 
-        $action->applyTo($shipment, Shipping::driver($driver)->track($shipment->tracking_number));
+        try {
+            $tracking = Shipping::driver($driver)->track($shipment->tracking_number);
+        } catch (TrackingNotFoundException) {
+            Log::warning('The carrier has no record of this tracking number.', [
+                'shipment_id' => $shipment->id,
+                'driver' => $driver,
+                'tracking_number' => $shipment->tracking_number,
+            ]);
+
+            return;
+        }
+
+        $action->applyTo($shipment, $tracking);
     }
 }

--- a/tests/Api/Feature/CarrierTrackingPipelineTest.php
+++ b/tests/Api/Feature/CarrierTrackingPipelineTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Laravel\Sanctum\Sanctum;
+use Shopper\Core\Enum\FulfillmentStatus;
+use Shopper\Core\Enum\OrderStatus;
+use Shopper\Core\Enum\PaymentStatus;
+use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Core\Enum\ShippingStatus;
+use Shopper\Core\Events\Orders\OrderCompleted;
+use Shopper\Core\Events\Orders\OrderShipmentDelivered;
+use Shopper\Core\Models\Carrier;
+use Shopper\Core\Models\Order;
+use Shopper\Core\Models\OrderItem;
+use Shopper\Core\Models\OrderShipping;
+use Tests\Core\Stubs\User;
+
+uses(Tests\Api\TestCase::class);
+
+/**
+ * @return array<string, mixed>
+ */
+function upsTrackingPayload(): array
+{
+    return ['trackResponse' => ['shipment' => [['package' => [[
+        'trackingNumber' => '1Z999AA10123456784',
+        'currentStatus' => ['type' => 'D', 'code' => 'KB', 'description' => 'Delivered'],
+        'deliveryDate' => [['type' => 'DEL', 'date' => '20260903']],
+        'activity' => [
+            [
+                'location' => ['address' => ['city' => 'Paris', 'countryCode' => 'FR']],
+                'status' => ['type' => 'D', 'code' => 'KB', 'description' => 'Delivered'],
+                'date' => '20260903',
+                'time' => '143000',
+                'gmtDate' => '20260903',
+                'gmtTime' => '12:30:00',
+                'gmtOffset' => '+02:00',
+            ],
+            [
+                'location' => ['address' => ['city' => 'Roissy', 'countryCode' => 'FR']],
+                'status' => ['type' => 'I', 'code' => 'DP', 'description' => 'Departed from facility'],
+                'gmtDate' => '20260902',
+                'gmtTime' => '06:15:00',
+            ],
+        ],
+    ]]]]]];
+}
+
+beforeEach(function (): void {
+    config()->set('shopper.shipping.drivers.ups', [
+        'enabled' => true,
+        'sandbox' => false,
+        'credentials' => [
+            'client_id' => 'client',
+            'client_secret' => 'secret',
+            'user_id' => 'user',
+            'account_number' => 'account',
+        ],
+    ]);
+
+    Http::fake([
+        'onlinetools.ups.com/security/v1/oauth/token' => Http::response(['access_token' => 'ups-token', 'expires_in' => 14399]),
+        'onlinetools.ups.com/api/track/v1/details/*' => Http::response(upsTrackingPayload()),
+    ]);
+
+    $this->customer = User::factory()->create();
+    $this->order = Order::factory()->create([
+        'customer_id' => $this->customer->id,
+        'status' => OrderStatus::Processing,
+        'payment_status' => PaymentStatus::Paid,
+        'shipping_status' => ShippingStatus::Shipped,
+    ]);
+    $this->carrier = Carrier::factory()->create(['name' => 'UPS', 'driver' => 'ups']);
+    $this->shipment = OrderShipping::factory()->create([
+        'order_id' => $this->order->id,
+        'carrier_id' => $this->carrier->id,
+        'status' => ShipmentStatus::Pending,
+        'tracking_number' => '1Z999AA10123456784',
+    ]);
+    $this->item = OrderItem::factory()->create([
+        'order_id' => $this->order->id,
+        'order_shipping_id' => $this->shipment->id,
+        'fulfillment_status' => FulfillmentStatus::Shipped,
+    ]);
+});
+
+it('walks a real UPS timeline from the scheduled command into the shipment', function (): void {
+    $this->artisan('shopper:shipments:sync-tracking')
+        ->expectsOutputToContain('Queued 1 shipment for tracking sync.')
+        ->assertSuccessful();
+
+    $this->shipment->refresh();
+
+    expect($this->shipment->status)->toBe(ShipmentStatus::Delivered)
+        ->and($this->shipment->received_at)->not->toBeNull()
+        ->and($this->shipment->events()->orderBy('occurred_at')->pluck('status')->all())
+        ->toBe([ShipmentStatus::InTransit, ShipmentStatus::OutForDelivery, ShipmentStatus::Delivered])
+        ->and($this->shipment->events()->orderBy('occurred_at')->pluck('external_id')->all())
+        ->toBe([
+            'ups:20260902061500:DP',
+            'ups:20260903123000:KB',
+            'ups:delivered:1Z999AA10123456784',
+        ]);
+});
+
+it('stays idempotent when the scheduled command runs again', function (): void {
+    $this->artisan('shopper:shipments:sync-tracking')->assertSuccessful();
+
+    $countAfterFirstRun = $this->shipment->events()->count();
+
+    $this->artisan('shopper:shipments:sync-tracking')->assertSuccessful();
+
+    expect($this->shipment->events()->count())->toBe($countAfterFirstRun);
+});
+
+it('serves the carrier timeline to the customer through the store API', function (): void {
+    $this->artisan('shopper:shipments:sync-tracking')->assertSuccessful();
+
+    Sanctum::actingAs($this->customer, ['store']);
+
+    $included = collect(
+        $this->getJson("/store/customers/me/orders/{$this->order->public_id}?include=shippings,shippings.events")
+            ->assertOk()
+            ->json('included')
+    );
+
+    $shipment = $included->firstWhere('type', 'order-shippings');
+    $events = $included->where('type', 'order-shipping-events')
+        ->sortBy('attributes.occurred_at')
+        ->values();
+
+    expect($shipment['attributes']['status'])->toBe('delivered')
+        ->and($shipment['attributes']['carrier_name'])->toBe('UPS')
+        ->and($shipment['attributes']['tracking_number'])->toBe('1Z999AA10123456784')
+        ->and($shipment['attributes']['received_at'])->not->toBeNull()
+        ->and($events->pluck('attributes.status')->all())->toBe(['in_transit', 'out_for_delivery', 'delivered'])
+        ->and($events->first()['attributes']['location'])->toBe('Roissy, FR');
+});
+
+it('drops the shipment out of the polling rotation once the carrier delivers it', function (): void {
+    $this->artisan('shopper:shipments:sync-tracking')->assertSuccessful();
+
+    $this->artisan('shopper:shipments:sync-tracking')
+        ->expectsOutputToContain('Queued 0 shipments for tracking sync.')
+        ->assertSuccessful();
+});
+
+it('advances the order fulfillment steps when the carrier delivers the parcel', function (): void {
+    Event::fake([OrderShipmentDelivered::class, OrderCompleted::class]);
+
+    $this->artisan('shopper:shipments:sync-tracking')->assertSuccessful();
+
+    expect($this->item->refresh()->fulfillment_status)->toBe(FulfillmentStatus::Delivered)
+        ->and($this->order->refresh()->shipping_status)->toBe(ShippingStatus::Delivered)
+        ->and($this->order->status)->toBe(OrderStatus::Completed);
+
+    Event::assertDispatched(OrderShipmentDelivered::class);
+    Event::assertDispatched(OrderCompleted::class);
+});

--- a/tests/Api/Feature/ShipmentTrackingSyncTest.php
+++ b/tests/Api/Feature/ShipmentTrackingSyncTest.php
@@ -10,6 +10,7 @@ use Shopper\Core\Models\OrderShipping;
 use Shopper\Shipping\Actions\ApplyTrackingInfoAction;
 use Shopper\Shipping\DataTransferObjects\TrackingEvent;
 use Shopper\Shipping\DataTransferObjects\TrackingInfo;
+use Shopper\Shipping\Exceptions\ShippingException;
 use Shopper\Shipping\Facades\Shipping;
 use Shopper\Shipping\Jobs\SyncShipmentTrackingJob;
 use Tests\Api\Stubs\FakeShippingDriver;
@@ -140,4 +141,51 @@ it('records a status-only tracking response once across runs', function (): void
     expect($shipment->events()->count())->toBe(1)
         ->and($shipment->refresh()->status)->toBe(ShipmentStatus::InTransit)
         ->and($shipment->shipped_at)->not->toBeNull();
+});
+
+it('stops polling a tracking number the carrier has no record of', function (): void {
+    Shipping::extend('fake', fn (): FakeShippingDriver => new FakeShippingDriver(
+        tracking: new TrackingInfo(trackingNumber: 'TRK-1', status: ShipmentStatus::InTransit),
+        notFound: true,
+    ));
+
+    $shipment = OrderShipping::factory()->create([
+        'carrier_id' => $this->carrier->id,
+        'status' => ShipmentStatus::Pending,
+        'tracking_number' => 'TRK-1',
+    ]);
+
+    (new SyncShipmentTrackingJob($shipment->id))->handle(resolve(ApplyTrackingInfoAction::class));
+
+    expect($shipment->events()->count())->toBe(0)
+        ->and($shipment->refresh()->status)->toBe(ShipmentStatus::Pending);
+});
+
+it('lets a carrier outage fail the job so the queue retries it', function (): void {
+    Shipping::extend('fake', fn (): FakeShippingDriver => new FakeShippingDriver(
+        fails: true,
+        tracking: new TrackingInfo(trackingNumber: 'TRK-1', status: ShipmentStatus::InTransit),
+    ));
+
+    $shipment = OrderShipping::factory()->create([
+        'carrier_id' => $this->carrier->id,
+        'status' => ShipmentStatus::Pending,
+        'tracking_number' => 'TRK-1',
+    ]);
+
+    expect(fn () => (new SyncShipmentTrackingJob($shipment->id))->handle(resolve(ApplyTrackingInfoAction::class)))
+        ->toThrow(ShippingException::class);
+});
+
+it('keeps the retry budget when the tracking backoff is misconfigured', function (): void {
+    $job = new SyncShipmentTrackingJob(1);
+
+    config()->set('shopper.shipping.tracking.backoff', null);
+    expect($job->backoff())->toBe([60, 300, 900])->and($job->tries())->toBe(4);
+
+    config()->set('shopper.shipping.tracking.backoff', 300);
+    expect($job->backoff())->toBe([300])->and($job->tries())->toBe(2);
+
+    config()->set('shopper.shipping.tracking.backoff', []);
+    expect($job->backoff())->toBe([])->and($job->tries())->toBe(1);
 });

--- a/tests/Api/Stubs/FakeShippingDriver.php
+++ b/tests/Api/Stubs/FakeShippingDriver.php
@@ -16,6 +16,7 @@ use Shopper\Shipping\DataTransferObjects\ShippingRate;
 use Shopper\Shipping\DataTransferObjects\TrackingEvent;
 use Shopper\Shipping\DataTransferObjects\TrackingInfo;
 use Shopper\Shipping\Exceptions\ShippingException;
+use Shopper\Shipping\Exceptions\TrackingNotFoundException;
 
 final class FakeShippingDriver implements ShippingDriver
 {
@@ -32,6 +33,7 @@ final class FakeShippingDriver implements ShippingDriver
         private readonly bool $configured = true,
         private readonly bool $webhooks = false,
         private readonly ?TrackingInfo $tracking = null,
+        private readonly bool $notFound = false,
     ) {}
 
     public function code(): string
@@ -93,6 +95,10 @@ final class FakeShippingDriver implements ShippingDriver
     public function track(string $trackingNumber): TrackingInfo
     {
         $this->trackings++;
+
+        if ($this->notFound) {
+            throw TrackingNotFoundException::for('fake', $trackingNumber);
+        }
 
         if ($this->fails || $this->tracking === null) {
             throw ShippingException::apiError('fake', 'Tracking unavailable');

--- a/tests/Shipping/CarrierTrackingTest.php
+++ b/tests/Shipping/CarrierTrackingTest.php
@@ -1,0 +1,539 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Shopper\Core\Enum\ShipmentStatus;
+use Shopper\Shipping\DataTransferObjects\TrackingEvent;
+use Shopper\Shipping\Drivers\FedExDriver;
+use Shopper\Shipping\Drivers\UpsDriver;
+use Shopper\Shipping\Exceptions\ShippingException;
+use Shopper\Shipping\Exceptions\TrackingNotFoundException;
+
+uses(Tests\Shipping\TestCase::class);
+
+const UPS_NUMBER = '1Z999AA10123456784';
+
+const FEDEX_NUMBER = '794644746162';
+
+function upsDriver(bool $sandbox = false): UpsDriver
+{
+    return new UpsDriver('client', 'secret', 'user', 'account', sandbox: $sandbox);
+}
+
+function fedexDriver(bool $sandbox = false): FedExDriver
+{
+    return new FedExDriver('client', 'secret', 'account', sandbox: $sandbox);
+}
+
+/**
+ * @param  array<string, mixed>  $package
+ * @return array<string, mixed>
+ */
+function upsResponse(array $package): array
+{
+    return ['trackResponse' => ['shipment' => [['package' => [$package]]]]];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function upsPackage(): array
+{
+    return upsResponse([
+        'trackingNumber' => UPS_NUMBER,
+        'currentStatus' => ['type' => 'D', 'code' => 'KB', 'description' => 'Delivered'],
+        'deliveryDate' => [
+            ['type' => 'SDD', 'date' => '20260903'],
+            ['type' => 'DEL', 'date' => '20260903'],
+        ],
+        'activity' => [
+            [
+                'location' => ['address' => ['city' => 'Paris', 'stateProvince' => '', 'countryCode' => 'FR']],
+                'status' => ['type' => 'D', 'code' => 'KB', 'description' => 'Delivered', 'statusCode' => '011'],
+                'date' => '20260903',
+                'time' => '143000',
+                'gmtDate' => '20260903',
+                'gmtTime' => '12:30:00',
+                'gmtOffset' => '+02:00',
+            ],
+            [
+                'location' => ['address' => ['city' => 'Roissy', 'countryCode' => 'FR']],
+                'status' => ['type' => 'I', 'code' => 'DP', 'description' => 'Departed from facility'],
+                'gmtDate' => '20260902',
+                'gmtTime' => '06:15:00',
+            ],
+            [
+                'status' => ['type' => 'P', 'code' => 'OR', 'description' => 'Origin scan'],
+                'date' => '20260901',
+                'time' => '170000',
+                'gmtOffset' => '+02:00',
+            ],
+            [
+                'status' => ['type' => 'M', 'code' => 'MP', 'description' => 'Shipper created a label'],
+                'date' => '20260901',
+                'time' => '090000',
+            ],
+        ],
+    ]);
+}
+
+/**
+ * @param  array<string, mixed>  $result
+ * @return array<string, mixed>
+ */
+function fedexResponse(array $result): array
+{
+    return ['output' => ['completeTrackResults' => [['trackResults' => [$result]]]]];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function fedexPackage(): array
+{
+    return fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'latestStatusDetail' => ['code' => 'DL', 'statusByLocale' => 'Delivered', 'description' => 'Delivered'],
+        'dateAndTimes' => [
+            ['type' => 'ACTUAL_DELIVERY', 'dateTime' => '2026-09-03T14:31:00-05:00'],
+            ['type' => 'ESTIMATED_DELIVERY', 'dateTime' => '2026-09-03T20:00:00-05:00'],
+        ],
+        'scanEvents' => [
+            [
+                'date' => '2026-09-03T14:31:00-05:00',
+                'eventType' => 'DL',
+                'eventDescription' => 'Delivered',
+                'derivedStatusCode' => 'DL',
+                'scanLocation' => ['city' => 'MEMPHIS', 'stateOrProvinceCode' => 'TN', 'countryCode' => 'US'],
+            ],
+            [
+                'date' => '2026-09-02T07:04:00-05:00',
+                'eventType' => 'DP',
+                'eventDescription' => 'Departed FedEx location',
+                'derivedStatusCode' => 'IT',
+                'scanLocation' => ['city' => 'MEMPHIS', 'countryCode' => 'US'],
+            ],
+            ['date' => 'not-a-date', 'eventType' => 'OC', 'derivedStatusCode' => 'OC'],
+        ],
+    ]);
+}
+
+function fakeUps(mixed $tracking, int $status = 200, mixed $token = null): void
+{
+    Http::fake([
+        'onlinetools.ups.com/security/v1/oauth/token' => Http::response($token ?? ['access_token' => 'ups-token', 'expires_in' => 14399]),
+        'onlinetools.ups.com/api/track/v1/details/*' => Http::response($tracking, $status),
+    ]);
+}
+
+function fakeFedEx(mixed $tracking, int $status = 200, mixed $token = null): void
+{
+    Http::fake([
+        'apis.fedex.com/oauth/token' => Http::response($token ?? ['access_token' => 'fedex-token', 'expires_in' => 3599]),
+        'apis.fedex.com/track/v1/trackingnumbers' => Http::response($tracking, $status),
+    ]);
+}
+
+/**
+ * @return array<int, string>
+ */
+function eventIds(mixed $info): array
+{
+    return collect($info->events)->map(fn (TrackingEvent $event): string => (string) $event->externalId)->all();
+}
+
+/**
+ * @return array<int, string>
+ */
+function eventStatuses(mixed $info): array
+{
+    return collect($info->events)->map(fn (TrackingEvent $event): string => $event->status->value)->all();
+}
+
+it('turns the UPS activity feed into shipment events timed from the GMT fields', function (): void {
+    fakeUps(upsPackage());
+
+    $info = upsDriver()->track(UPS_NUMBER);
+
+    expect($info->status)->toBe(ShipmentStatus::Delivered)
+        ->and($info->statusDescription)->toBe('Delivered')
+        ->and($info->deliveredAt?->format('Y-m-d H:i:s e'))->toBe('2026-09-03 12:30:00 UTC')
+        ->and($info->estimatedDelivery?->format('Y-m-d H:i:s'))->toBe('2026-09-03 00:00:00')
+        ->and(eventStatuses($info))->toBe(['out_for_delivery', 'in_transit', 'picked_up', 'delivered'])
+        ->and(eventIds($info))->toBe([
+            'ups:20260903123000:KB',
+            'ups:20260902061500:DP',
+            'ups:20260901150000:OR',
+            'ups:delivered:'.UPS_NUMBER,
+        ])
+        ->and(collect($info->events)->first()->location)->toBe('Paris, FR');
+});
+
+it('times a UPS activity from its local stamp and offset when the GMT fields are absent', function (): void {
+    fakeUps(upsPackage());
+
+    $picked = collect(upsDriver()->track(UPS_NUMBER)->events)
+        ->firstWhere(fn (TrackingEvent $event): bool => $event->status === ShipmentStatus::PickedUp);
+
+    expect($picked->occurredAt->format('Y-m-d H:i:s'))->toBe('2026-09-01 15:00:00');
+});
+
+it('never guesses the instant of a UPS activity that carries neither a GMT stamp nor an offset', function (): void {
+    fakeUps(upsPackage());
+
+    expect(collect(upsDriver()->track(UPS_NUMBER)->events)->pluck('description')->all())
+        ->not->toContain('Shipper created a label');
+});
+
+it('keeps a UPS parcel out of the delivered state until the carrier dates the delivery', function (): void {
+    $payload = upsPackage();
+    unset($payload['trackResponse']['shipment'][0]['package'][0]['deliveryDate'][1]);
+
+    fakeUps($payload);
+
+    $info = upsDriver()->track(UPS_NUMBER);
+
+    expect($info->status)->toBe(ShipmentStatus::OutForDelivery)
+        ->and($info->deliveredAt)->toBeNull()
+        ->and($info->events)->toHaveCount(3);
+});
+
+it('refuses to invent a UPS delivery instant when no scan carries the delivery date', function (): void {
+    $payload = upsPackage();
+    $payload['trackResponse']['shipment'][0]['package'][0]['deliveryDate'] = [['type' => 'DEL', 'date' => '20260905']];
+
+    fakeUps($payload);
+
+    $info = upsDriver()->track(UPS_NUMBER);
+
+    expect($info->deliveredAt)->toBeNull()
+        ->and($info->status)->toBe(ShipmentStatus::OutForDelivery);
+});
+
+it('prefers the rescheduled UPS delivery date over the scheduled one', function (): void {
+    $payload = upsPackage();
+    $payload['trackResponse']['shipment'][0]['package'][0]['deliveryDate'] = [
+        ['type' => 'SDD', 'date' => '20260903'],
+        ['type' => 'RDD', 'date' => '20260904'],
+    ];
+
+    fakeUps($payload);
+
+    expect(upsDriver()->track(UPS_NUMBER)->estimatedDelivery?->format('Y-m-d'))->toBe('2026-09-04');
+});
+
+it('rejects a UPS delivery date that is not a real calendar day', function (): void {
+    $payload = upsPackage();
+    $payload['trackResponse']['shipment'][0]['package'][0]['deliveryDate'] = [
+        ['type' => 'SDD', 'date' => '20261345'],
+        ['type' => 'DEL', 'date' => '00000000'],
+    ];
+
+    fakeUps($payload);
+
+    $info = upsDriver()->track(UPS_NUMBER);
+
+    expect($info->estimatedDelivery)->toBeNull()
+        ->and($info->deliveredAt)->toBeNull();
+});
+
+it('reads the UPS status from the current status when no scan can be timed', function (): void {
+    fakeUps(upsResponse([
+        'trackingNumber' => UPS_NUMBER,
+        'currentStatus' => ['type' => 'M', 'description' => 'Label created'],
+        'activity' => [],
+    ]));
+
+    $info = upsDriver()->track(UPS_NUMBER);
+
+    expect($info->events)->toBe([])
+        ->and($info->status)->toBe(ShipmentStatus::Pending)
+        ->and($info->statusDescription)->toBe('Label created')
+        ->and($info->deliveredAt)->toBeNull();
+});
+
+it('falls back to pending when UPS reports neither scans nor a current status', function (): void {
+    fakeUps(upsResponse(['trackingNumber' => UPS_NUMBER]));
+
+    expect(upsDriver()->track(UPS_NUMBER)->status)->toBe(ShipmentStatus::Pending);
+});
+
+it('breaks a UPS rank tie on the scan time rather than the feed order', function (): void {
+    fakeUps(upsResponse([
+        'trackingNumber' => UPS_NUMBER,
+        'activity' => [
+            [
+                'status' => ['type' => 'X', 'code' => 'RD', 'description' => 'Delivery attempted'],
+                'gmtDate' => '20260903',
+                'gmtTime' => '10:00:00',
+            ],
+            [
+                'status' => ['type' => 'D', 'code' => 'OF', 'description' => 'Out for delivery'],
+                'gmtDate' => '20260904',
+                'gmtTime' => '09:00:00',
+            ],
+        ],
+    ]));
+
+    expect(upsDriver()->track(UPS_NUMBER)->status)->toBe(ShipmentStatus::OutForDelivery);
+});
+
+it('reuses the UPS access token across separate driver instances', function (): void {
+    fakeUps(upsPackage());
+
+    upsDriver()->track(UPS_NUMBER);
+    upsDriver()->track(UPS_NUMBER);
+
+    Http::assertSentCount(3);
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/api/track/v1/details/')
+        && $request->hasHeader('Authorization', 'Bearer ups-token'));
+});
+
+it('refetches the UPS access token once the cached one has expired', function (): void {
+    Http::fake([
+        'onlinetools.ups.com/security/v1/oauth/token' => Http::sequence()
+            ->push(['access_token' => 'ups-token-1', 'expires_in' => 61])
+            ->push(['access_token' => 'ups-token-2', 'expires_in' => 61]),
+        'onlinetools.ups.com/api/track/v1/details/*' => Http::response(upsPackage()),
+    ]);
+
+    upsDriver()->track(UPS_NUMBER);
+
+    $this->travel(2)->minutes();
+
+    upsDriver()->track(UPS_NUMBER);
+
+    Http::assertSentCount(4);
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), '/api/track/v1/details/')
+        && $request->hasHeader('Authorization', 'Bearer ups-token-2'));
+});
+
+it('sends a UPS transaction id the carrier will accept', function (): void {
+    fakeUps(upsPackage());
+
+    upsDriver()->track(UPS_NUMBER);
+
+    Http::assertSent(fn ($request): bool => ! str_contains($request->url(), '/api/track/v1/details/')
+        || mb_strlen($request->header('transId')[0]) === 32);
+});
+
+it('escapes a UPS tracking number instead of letting it shape the request path', function (): void {
+    fakeUps(upsPackage());
+
+    upsDriver()->track('1Z999/../oauth/token');
+
+    Http::assertSent(fn ($request): bool => ! str_contains($request->url(), '/api/track/v1/details/')
+        || str_contains($request->url(), '/api/track/v1/details/1Z999%2F..%2Foauth%2Ftoken'));
+});
+
+it('tracks against the UPS sandbox host when the driver runs in sandbox mode', function (): void {
+    Http::fake([
+        'wwwcie.ups.com/security/v1/oauth/token' => Http::response(['access_token' => 'ups-sandbox', 'expires_in' => 14399]),
+        'wwwcie.ups.com/api/track/v1/details/*' => Http::response(upsPackage()),
+    ]);
+
+    upsDriver(sandbox: true)->track(UPS_NUMBER);
+
+    Http::assertSent(fn ($request): bool => str_starts_with($request->url(), 'https://wwwcie.ups.com/'));
+});
+
+it('reports a tracking number UPS has no record of as not found', function (): void {
+    fakeUps(['response' => ['errors' => [['code' => 'TW0001', 'message' => 'Tracking Information Not Found']]]], 404);
+
+    expect(fn () => upsDriver()->track(UPS_NUMBER))
+        ->toThrow(TrackingNotFoundException::class);
+});
+
+it('never reads a bare UPS 404 as a missing parcel', function (): void {
+    fakeUps('<html>Not Found</html>', 404);
+
+    expect(fn () => upsDriver()->track(UPS_NUMBER))
+        ->toThrow(ShippingException::class, 'API error from [ups]: HTTP 404')
+        ->and(fn () => upsDriver()->track(UPS_NUMBER))
+        ->not->toThrow(TrackingNotFoundException::class);
+});
+
+it('surfaces a UPS outage as a retryable api error', function (): void {
+    fakeUps(['response' => ['errors' => [['code' => '250002', 'message' => 'Invalid Authentication Information']]]], 503);
+
+    expect(fn () => upsDriver()->track(UPS_NUMBER))
+        ->toThrow(ShippingException::class, 'API error from [ups]: Invalid Authentication Information');
+});
+
+it('rejects a UPS response that carries no package', function (): void {
+    fakeUps(['trackResponse' => ['shipment' => [['inquiryNumber' => UPS_NUMBER]]]]);
+
+    expect(fn () => upsDriver()->track(UPS_NUMBER))
+        ->toThrow(ShippingException::class, 'Invalid response received from [ups] API.');
+});
+
+it('rejects a UPS token response that carries no access token', function (): void {
+    fakeUps(upsPackage(), token: ['token_type' => 'Bearer', 'expires_in' => 14399]);
+
+    expect(fn () => upsDriver()->track(UPS_NUMBER))
+        ->toThrow(ShippingException::class, 'Invalid response received from [ups] API.');
+
+    Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/api/track/v1/details/'));
+});
+
+it('never calls the UPS tracking endpoint when the credentials are refused', function (): void {
+    Http::fake([
+        'onlinetools.ups.com/security/v1/oauth/token' => Http::response(['response' => ['errors' => [['code' => '10401', 'message' => 'Unauthorized']]]], 401),
+        'onlinetools.ups.com/api/track/v1/details/*' => Http::response(upsPackage()),
+    ]);
+
+    expect(fn () => upsDriver()->track(UPS_NUMBER))
+        ->toThrow(ShippingException::class, 'API error from [ups]: Unauthorized');
+
+    Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/api/track/v1/details/'));
+});
+
+it('turns the FedEx scan events into shipment events keyed on the raw scan code', function (): void {
+    fakeFedEx(fedexPackage());
+
+    $info = fedexDriver()->track(FEDEX_NUMBER);
+
+    expect($info->status)->toBe(ShipmentStatus::Delivered)
+        ->and($info->statusDescription)->toBe('Delivered')
+        ->and($info->deliveredAt?->format('Y-m-d H:i:s e'))->toBe('2026-09-03 19:31:00 UTC')
+        ->and($info->estimatedDelivery?->format('Y-m-d H:i:s e'))->toBe('2026-09-04 01:00:00 UTC')
+        ->and(eventStatuses($info))->toBe(['delivered', 'in_transit'])
+        ->and(eventIds($info))->toBe(['fedex:20260903193100:DL', 'fedex:20260902120400:DP'])
+        ->and(collect($info->events)->first()->location)->toBe('MEMPHIS, TN, US');
+});
+
+it('records a FedEx delivery even when its own scan cannot be timed', function (): void {
+    fakeFedEx(fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'latestStatusDetail' => ['statusByLocale' => 'Delivered'],
+        'dateAndTimes' => [['type' => 'ACTUAL_DELIVERY', 'dateTime' => '2026-09-03T14:31:00-05:00']],
+        'scanEvents' => [
+            ['date' => '', 'eventType' => 'DL', 'derivedStatusCode' => 'DL', 'eventDescription' => 'Delivered'],
+            ['date' => '2026-09-02T07:04:00-05:00', 'eventType' => 'AR', 'derivedStatusCode' => 'AR'],
+        ],
+    ]));
+
+    $info = fedexDriver()->track(FEDEX_NUMBER);
+
+    expect($info->status)->toBe(ShipmentStatus::Delivered)
+        ->and(eventIds($info))->toBe(['fedex:20260902120400:AR', 'fedex:delivered:'.FEDEX_NUMBER])
+        ->and($info->deliveredAt?->format('Y-m-d H:i:s e'))->toBe('2026-09-03 19:31:00 UTC');
+});
+
+it('derives the FedEx delivered instant from the scan when no delivery date is reported', function (): void {
+    fakeFedEx(fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'latestStatusDetail' => ['statusByLocale' => 'Delivered'],
+        'scanEvents' => [
+            ['date' => '2026-09-03T14:31:00-05:00', 'eventType' => 'DL', 'derivedStatusCode' => 'DL'],
+        ],
+    ]));
+
+    $info = fedexDriver()->track(FEDEX_NUMBER);
+
+    expect($info->deliveredAt?->format('Y-m-d H:i:s e'))->toBe('2026-09-03 19:31:00 UTC')
+        ->and($info->events)->toHaveCount(1);
+});
+
+it('prefers the localized FedEx status over the raw description', function (): void {
+    fakeFedEx(fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'latestStatusDetail' => ['statusByLocale' => 'Livré', 'description' => 'Delivered'],
+    ]));
+
+    expect(fedexDriver()->track(FEDEX_NUMBER)->statusDescription)->toBe('Livré');
+});
+
+it('reports a FedEx shipment with no scans yet as pending', function (): void {
+    fakeFedEx(fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'latestStatusDetail' => ['description' => 'Label created'],
+    ]));
+
+    $info = fedexDriver()->track(FEDEX_NUMBER);
+
+    expect($info->events)->toBe([])
+        ->and($info->status)->toBe(ShipmentStatus::Pending)
+        ->and($info->statusDescription)->toBe('Label created')
+        ->and($info->deliveredAt)->toBeNull();
+});
+
+it('tracks against the FedEx sandbox host when the driver runs in sandbox mode', function (): void {
+    Http::fake([
+        'apis-sandbox.fedex.com/oauth/token' => Http::response(['access_token' => 'fedex-sandbox', 'expires_in' => 3599]),
+        'apis-sandbox.fedex.com/track/v1/trackingnumbers' => Http::response(fedexPackage()),
+    ]);
+
+    fedexDriver(sandbox: true)->track(FEDEX_NUMBER);
+
+    Http::assertSent(fn ($request): bool => str_starts_with($request->url(), 'https://apis-sandbox.fedex.com/'));
+});
+
+it('reports a tracking number FedEx has no record of as not found', function (): void {
+    fakeFedEx(fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'error' => ['code' => 'TRACKING.TRACKINGNUMBER.NOTFOUND', 'message' => 'Invalid tracking numbers.'],
+    ]));
+
+    expect(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->toThrow(TrackingNotFoundException::class);
+});
+
+it('surfaces a FedEx result error as a retryable api error', function (): void {
+    fakeFedEx(fedexResponse([
+        'trackingNumberInfo' => ['trackingNumber' => FEDEX_NUMBER],
+        'error' => ['code' => 'SYSTEM.UNEXPECTED.ERROR', 'message' => 'The system is temporarily unavailable.'],
+    ]));
+
+    expect(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->toThrow(ShippingException::class, 'API error from [fedex]: The system is temporarily unavailable.')
+        ->and(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->not->toThrow(TrackingNotFoundException::class);
+});
+
+it('surfaces a FedEx http outage as a retryable api error', function (): void {
+    fakeFedEx(['output' => ['alerts' => [['message' => 'Service temporarily unavailable']]]], 500);
+
+    expect(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->toThrow(ShippingException::class, 'API error from [fedex]: Service temporarily unavailable');
+});
+
+it('rejects a FedEx response that carries no track result', function (): void {
+    fakeFedEx(['output' => ['completeTrackResults' => [['trackResults' => []]]]]);
+
+    expect(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->toThrow(ShippingException::class, 'Invalid response received from [fedex] API.');
+});
+
+it('rejects a FedEx token response that carries no access token', function (): void {
+    fakeFedEx(fedexPackage(), token: ['token_type' => 'bearer']);
+
+    expect(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->toThrow(ShippingException::class, 'Invalid response received from [fedex] API.');
+
+    Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/track/v1/trackingnumbers'));
+});
+
+it('never calls the FedEx tracking endpoint when the credentials are refused', function (): void {
+    Http::fake([
+        'apis.fedex.com/oauth/token' => Http::response(['error' => 'invalid_client', 'error_description' => 'Bad credentials'], 401),
+        'apis.fedex.com/track/v1/trackingnumbers' => Http::response(fedexPackage()),
+    ]);
+
+    expect(fn () => fedexDriver()->track(FEDEX_NUMBER))
+        ->toThrow(ShippingException::class, 'API error from [fedex]: Bad credentials');
+
+    Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/track/v1/trackingnumbers'));
+});
+
+it('refuses to track before the carrier credentials are configured', function (): void {
+    Http::fake();
+
+    expect(fn () => (new UpsDriver('', '', '', ''))->track(UPS_NUMBER))
+        ->toThrow(ShippingException::class, 'The [ups] shipping driver is not configured. Please check your .env file.')
+        ->and(fn () => (new FedExDriver('', '', ''))->track(FEDEX_NUMBER))
+        ->toThrow(ShippingException::class, 'The [fedex] shipping driver is not configured. Please check your .env file.');
+
+    Http::assertNothingSent();
+});

--- a/tests/Shipping/TestCase.php
+++ b/tests/Shipping/TestCase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Shipping;
+
+use Illuminate\Support\Facades\Http;
+use Livewire\LivewireServiceProvider;
+use Shopper\Core\CoreServiceProvider;
+use Shopper\Shipping\ShippingServiceProvider;
+use Shopper\ShopperServiceProvider;
+use Shopper\Sidebar\SidebarServiceProvider;
+use Spatie\MediaLibrary\MediaLibraryServiceProvider;
+use Spatie\Permission\PermissionRegistrar;
+use Spatie\Permission\PermissionServiceProvider;
+
+abstract class TestCase extends \Tests\TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->make(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        Http::preventStrayRequests();
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('cache.default', 'array');
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            LivewireServiceProvider::class,
+            CoreServiceProvider::class,
+            ShopperServiceProvider::class,
+            SidebarServiceProvider::class,
+            MediaLibraryServiceProvider::class,
+            PermissionServiceProvider::class,
+            ShippingServiceProvider::class,
+        ];
+    }
+}


### PR DESCRIPTION
`UpsDriver::track()` and `FedExDriver::track()` reported `supportsTracking(): true` and then threw `notSupported`, so `shopper:shipments:sync-tracking` failed on every run for the two carriers it selected. Claiming a capability and failing on it is worse than not having it.

Both drivers now call the carrier tracking APIs through Laravel's HTTP client. The vendor library behind the rate quotes ships no tracking at all and wraps UPS and FedEx in its own Guzzle client, so it could neither be used nor faked here. Access tokens are cached per credential and per environment behind a lock, so a cold cache does not turn into one OAuth request per queue worker.

### Event identity

Neither carrier exposes a scan id, so the driver builds one from the carrier instant plus the status code, and never from the location, which is free text a carrier can reformat at will. Without this the generic fingerprint in `ApplyTrackingInfoAction` would re-identify an entire timeline the day `PARIS, FR` becomes `Paris, France`.

### Timestamps

UPS scans are timed from `gmtDate` and `gmtTime`, falling back to the local stamp plus `gmtOffset`. A scan carrying neither is dropped rather than dated from a wall clock with no zone.

UPS never maps activity type `D` to delivered: the carrier documents it as loaded on the vehicle, out for delivery and delivered, indistinctly, so reading it as a delivery would stamp `received_at` and complete the order on a parcel still on the truck. Delivery comes from `deliveryDate` of type `DEL`, matched against the scan falling on the same local day, since that date carries no offset and is the destination local day.

FedEx synthesises its delivered event when the carrier dates the delivery but its own `DL` scan cannot be timed. Without it a paid and delivered order stayed open forever while being re-polled every thirty minutes.

### Failure semantics

A tracking number the carrier has no record of raises `TrackingNotFoundException`, which the job catches and logs before returning. The shipment is no longer retried four times per tick for a parcel that will never exist.

A 404 without the carrier error envelope stays a loud API error. A bare 404 is also how a wrong path, a retired endpoint or an intercepting proxy answers, and swallowing it would freeze fulfillment store wide with a green queue and no alert.

Tracking numbers are escaped before they reach the request path. The admin field that feeds them carries no validation rule, so the value reaching the carrier was whatever an `orders.edit` user typed.

### Status mapping

Reduced to the fields both carriers document, with every unknown code falling back to `InTransit`, whose rank cannot regress a shipment past the `outranks()` guard. `Returned` is reachable on FedEx through `RS` and is not reachable on UPS, whose status type cannot express it.

### Also

`supportsLabels()` now reports `false` on both drivers, which is what `createShipment()` has always done. The overrides that duplicated the base class exception are gone.
